### PR TITLE
Add manual Astro project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Astro Project
+
+This repository contains a minimal Astro project generated manually due to environment constraints.
+
+Pages included:
+- Programs
+- Games
+- Members (Supabase placeholder)
+- AI Art Gallery
+- Artist Profile with links to Spotify, Apple Music, and YouTube
+- About Me
+- Mailing List Signup
+
+Run `npm install` (requires internet) then `npm run dev` to start.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'http://localhost/',
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "testing-astro-project",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^4.0.0"
+  }
+}

--- a/src/pages/about-me.astro
+++ b/src/pages/about-me.astro
@@ -1,0 +1,11 @@
+---
+---
+<html>
+  <head>
+    <title>About Me</title>
+  </head>
+  <body>
+    <h1>About Me</h1>
+    <p>This is the about me section.</p>
+  </body>
+</html>

--- a/src/pages/ai-art.astro
+++ b/src/pages/ai-art.astro
@@ -1,0 +1,11 @@
+---
+---
+<html>
+  <head>
+    <title>AI Art Gallery</title>
+  </head>
+  <body>
+    <h1>AI Art Gallery</h1>
+    <p>Placeholder for AI-generated art.</p>
+  </body>
+</html>

--- a/src/pages/artist-profile.astro
+++ b/src/pages/artist-profile.astro
@@ -1,0 +1,15 @@
+---
+---
+<html>
+  <head>
+    <title>Artist Profile</title>
+  </head>
+  <body>
+    <h1>Artist Profile</h1>
+    <ul>
+      <li><a href="https://spotify.com">Spotify</a></li>
+      <li><a href="https://music.apple.com">Apple Music</a></li>
+      <li><a href="https://youtube.com">YouTube</a></li>
+    </ul>
+  </body>
+</html>

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,0 +1,14 @@
+---
+---
+<html>
+  <head>
+    <title>Games</title>
+  </head>
+  <body>
+    <h1>Games</h1>
+    <ul>
+      <li>Game A</li>
+      <li>Game B</li>
+    </ul>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+---
+<html>
+  <head>
+    <title>Home</title>
+  </head>
+  <body>
+    <h1>Welcome to the Astro Project</h1>
+  </body>
+</html>

--- a/src/pages/mailing-list.astro
+++ b/src/pages/mailing-list.astro
@@ -1,0 +1,14 @@
+---
+---
+<html>
+  <head>
+    <title>Mailing List Signup</title>
+  </head>
+  <body>
+    <h1>Mailing List Signup</h1>
+    <form action="#" method="post">
+      <input type="email" name="email" placeholder="Your email" />
+      <button type="submit">Subscribe</button>
+    </form>
+  </body>
+</html>

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -1,0 +1,11 @@
+---
+---
+<html>
+  <head>
+    <title>Members</title>
+  </head>
+  <body>
+    <h1>Members</h1>
+    <p>Supabase authentication placeholder.</p>
+  </body>
+</html>

--- a/src/pages/programs.astro
+++ b/src/pages/programs.astro
@@ -1,0 +1,14 @@
+---
+---
+<html>
+  <head>
+    <title>Programs</title>
+  </head>
+  <body>
+    <h1>Programs</h1>
+    <ul>
+      <li>Program 1</li>
+      <li>Program 2</li>
+    </ul>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- attempted to run `npm create astro@latest` but it failed due to network restrictions
- manually add a minimal Astro project
- include pages for Programs, Games, Members, AI Art, Artist Profile, About Me and Mailing List signup

## Testing
- `npm create astro@latest` *(fails: unable to download template)*

------
https://chatgpt.com/codex/tasks/task_e_684202b8c720833293be2530cea28464