### PR TITLE
Add basic level editor and mobile enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,6 +352,9 @@
                 <div>Find the glowing door to advance to the next level.</div>
                 <div id="playerCount" style="color: #00ff88; margin-top: 10px;">Players online: 1</div>
                 <button id="vrToggle" class="mobile-btn" style="display: none;">Enable VR</button>
+                <button id="editorToggle" class="mobile-btn">Editor Mode</button>
+                <button id="gyroToggle" class="mobile-btn" style="display:none;">Gyro Look</button>
+                <button id="qualityToggle" class="mobile-btn">High Quality</button>
                 <button id="fsToggle" class="mobile-btn">Enter Fullscreen</button>
                 <button id="uiToggle" class="mobile-btn">Hide UI</button>
             </div>

--- a/src/levelEditor.js
+++ b/src/levelEditor.js
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+
+export class LevelEditor {
+    constructor(game) {
+        this.game = game;
+        this.isEditing = false;
+        this.editedObjects = [];
+        this.objectMaterial = new THREE.MeshStandardMaterial({ color: 0x8888ff });
+    }
+
+    toggle() {
+        this.isEditing = !this.isEditing;
+        if (this.isEditing) {
+            this.enableEditing();
+        } else {
+            this.disableEditing();
+        }
+    }
+
+    enableEditing() {
+        this.pointerHandler = (event) => this.onPointerDown(event);
+        this.game.renderer.domElement.addEventListener('pointerdown', this.pointerHandler);
+    }
+
+    disableEditing() {
+        this.game.renderer.domElement.removeEventListener('pointerdown', this.pointerHandler);
+    }
+
+    onPointerDown(event) {
+        const rect = this.game.renderer.domElement.getBoundingClientRect();
+        const mouse = new THREE.Vector2(
+            ((event.clientX - rect.left) / rect.width) * 2 - 1,
+            -((event.clientY - rect.top) / rect.height) * 2 + 1
+        );
+
+        this.game.raycaster.setFromCamera(mouse, this.game.camera);
+        const intersects = this.game.raycaster.intersectObjects(this.game.scene.children, true);
+        if (intersects.length > 0) {
+            const point = intersects[0].point.clone();
+            const geometry = new THREE.BoxGeometry(1, 1, 1);
+            const mesh = new THREE.Mesh(geometry, this.objectMaterial);
+            mesh.position.copy(point).add(new THREE.Vector3(0, 0.5, 0));
+            this.game.scene.add(mesh);
+            this.editedObjects.push(mesh);
+        }
+    }
+
+    save() {
+        const data = this.editedObjects.map(obj => ({ position: obj.position.toArray() }));
+        localStorage.setItem('customLevel', JSON.stringify(data));
+    }
+
+    load() {
+        const raw = localStorage.getItem('customLevel');
+        if (!raw) return;
+        const objects = JSON.parse(raw);
+        objects.forEach(o => {
+            const geometry = new THREE.BoxGeometry(1, 1, 1);
+            const mesh = new THREE.Mesh(geometry, this.objectMaterial);
+            mesh.position.fromArray(o.position);
+            this.game.scene.add(mesh);
+            this.editedObjects.push(mesh);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add buttons for editor, gyroscope look and quality settings
- implement LevelEditor helper
- add BasicEnemy AI and spawn on level load
- support gyroscope look and quality cycles
- start tracking points as progression
- generate procedural levels when model path is `procedural`

## Testing
- `node --check src/game.js`

------
https://chatgpt.com/codex/tasks/task_e_6845d7b2a79883328b3994c54a59aa87