### PR TITLE
Use fictional locations instead of real addresses

### DIFF
--- a/components/popup-module.html
+++ b/components/popup-module.html
@@ -1,6 +1,6 @@
 <div id="popup-module">
             <h2>Add Survey Point</h2>
-            <p id="geocoded-address">Address: N/A</p>
+            <p id="geocoded-address">Location: N/A</p>
             <p id="coordinates">Coordinates: N/A</p>
             <select id="point-type-select-popup">
                 <option value="Survey Point">Survey Point</option>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         "js/loadoutManager.js": "./js/loadoutManager.js",
         "js/lazyLoad.js": "./js/lazyLoad.js",
         "js/tutorial.js": "./js/tutorial/index.js",
+        "js/fictionalLocation.js": "./js/fictionalLocation.js",
         "osmtogeojson": "https://esm.sh/osmtogeojson@3.0.0-beta.5",
         "@turf/bbox-polygon": "https://esm.sh/@turf/bbox-polygon@6.5.0",
         "@turf/intersect": "https://esm.sh/@turf/intersect@6.5.0",

--- a/js/eventFinder.js
+++ b/js/eventFinder.js
@@ -3,6 +3,7 @@ import { lineString } from '@turf/helpers';
 import pointOnFeature from '@turf/point-on-feature';
 import lineSplit from '@turf/line-split';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
+import { getFictionalLocationName } from './fictionalLocation.js';
 
 const eventTitles = [
   "Straight-Up Skirmish",
@@ -28,15 +29,8 @@ function getRandomEventTitle() {
   return eventTitles[Math.floor(Math.random() * eventTitles.length)];
 }
 
-async function getAddressForLatLng(lat, lng) {
-  try {
-    const response = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`);
-    const data = await response.json();
-    return data.display_name || "Address not found";
-  } catch (error) {
-    console.error("Error reverse-geocoding for event:", error);
-    return "Address lookup failed";
-  }
+function getAddressForLatLng(lat, lng) {
+  return getFictionalLocationName(lat, lng);
 }
 
 // Start an event after preparation is complete
@@ -44,7 +38,7 @@ export function startEvent(eventId, eventTitle, eventAddress, eventLat, eventLng
   console.log(`Starting event: ${eventId} - ${eventTitle} at ${eventAddress}`);
   const latText = eventLat !== undefined ? eventLat.toFixed(6) : 'N/A';
   const lngText = eventLng !== undefined ? eventLng.toFixed(6) : 'N/A';
-  alert(`Launching event: ${eventTitle}\nAddress: ${eventAddress}\nLocation: ${latText}, ${lngText}`);
+  alert(`Launching event: ${eventTitle}\nLocation: ${eventAddress}\nCoordinates: ${latText}, ${lngText}`);
 }
 // Make available globally for any UI callbacks
 window.startEvent = startEvent;
@@ -141,7 +135,7 @@ async function routeToEvent(eventId, eventLat, eventLng) {
   }
 
   if (marker && eventData) { 
-      const popupContent = `<b>${eventData.title}</b><br>Address: ${eventData.address}<br>${routeDistanceText}<br>${airDistanceText}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventData.title.replace(/'/g, "\\'")}', '${eventData.address.replace(/'/g, "\\'")}', ${eventLat}, ${eventLng})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${eventLat}, ${eventLng})">Route to Event</button>`;
+      const popupContent = `<b>${eventData.title}</b><br>Location: ${eventData.address}<br>${routeDistanceText}<br>${airDistanceText}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventData.title.replace(/'/g, "\\'")}', '${eventData.address.replace(/'/g, "\\'")}', ${eventLat}, ${eventLng})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${eventLat}, ${eventLng})">Route to Event</button>`;
       marker.setPopupContent(popupContent);
       if (!marker.isPopupOpen()) {
           marker.openPopup();
@@ -252,12 +246,12 @@ export function initEventFinder(map) {
         const ptOnLine = pointOnFeature(segment); 
         if (ptOnLine && ptOnLine.geometry && ptOnLine.geometry.coordinates) {
           const latLng = [ptOnLine.geometry.coordinates[1], ptOnLine.geometry.coordinates[0]];
-          const address = await getAddressForLatLng(latLng[0], latLng[1]);
+          const address = getAddressForLatLng(latLng[0], latLng[1]);
           const eventTitle = getRandomEventTitle();
           const eventId = `event-${Date.now()}-${i}`; 
   
           const marker = L.marker(latLng, { icon: eventIcon })
-            .bindPopup(`<b>${eventTitle}</b><br>Address: ${address}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventTitle.replace(/'/g, "\\'")}', '${address.replace(/'/g, "\\'")}', ${latLng[0]}, ${latLng[1]})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${latLng[0]}, ${latLng[1]})">Route to Event</button>`);
+            .bindPopup(`<b>${eventTitle}</b><br>Location: ${address}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventTitle.replace(/'/g, "\\'")}', '${address.replace(/'/g, "\\'")}', ${latLng[0]}, ${latLng[1]})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${latLng[0]}, ${latLng[1]})">Route to Event</button>`);
           
           marker.eventId = eventId; // Store eventId on the marker
           marker.addTo(eventLayerGroup);

--- a/js/fictionalLocation.js
+++ b/js/fictionalLocation.js
@@ -1,0 +1,8 @@
+export function getFictionalLocationName(lat, lng) {
+  const adjectives = ['Mystic', 'Shadow', 'Crimson', 'Iron', 'Silver', 'Golden', 'Emerald', 'Silent', 'Hidden', 'Radiant'];
+  const nouns = ['Haven', 'Valley', 'Outpost', 'Keep', 'Crossing', 'Bastion', 'Harbor', 'Sanctum', 'Frontier', 'Beacon'];
+  const seed = Math.abs(Math.floor(lat * 1000) + Math.floor(lng * 1000));
+  const adj = adjectives[seed % adjectives.length];
+  const noun = nouns[Math.floor(seed / adjectives.length) % nouns.length];
+  return `${adj} ${noun}`;
+}

--- a/js/gddModal.js
+++ b/js/gddModal.js
@@ -6,7 +6,7 @@ const gameplayFunctionalities = [
     { name: "Road Mapping", description: "Fetches and displays road networks from OpenStreetMap for selected map areas." },
     { name: "Event Generation", description: "Dynamically finds and places interactive events on the map within road networks." },
     { name: "Geolocation & Home Base", description: "Displays user's or a fixed 'Home Base' location on the map." },
-    { name: "POI Placement & Geocoding", description: "Allows users to place Points of Interest (POIs) on the map with reverse geocoded addresses." },
+    { name: "POI Placement & Geocoding", description: "Allows users to place Points of Interest (POIs) on the map with generated fictional location names." },
     { name: "Sidebar Navigation", description: "Right sidebar for accessing various tools and external content via iframes." },
     { name: "Street View Integration", description: "Google Street View display for selected map locations, integrated into a panel." },
     { name: "Terra Incognita Overlay", description: "Dynamic map overlay that blacks out non-US countries, emphasizing the game's focus area." },

--- a/js/map.js
+++ b/js/map.js
@@ -2,6 +2,7 @@ import { initMapBase } from "./mapBase.js";
 import { initGridOverlay } from "./grid.js";
 import { initGeoLocation } from "./geolocation.js";
 import { initMarkerWithAddress } from "./markerWithAddress.js";
+import { getFictionalLocationName } from "./fictionalLocation.js";
 import { initTerraIncognita } from "./terraIncognita.js";
 import { initWestOverlay } from "./westOverlay.js";
 import { initEastOverlay } from "./eastOverlay.js";
@@ -17,24 +18,14 @@ function initMap() {
   initEastOverlay(map);
   initDMZOverlay(map);
 
-  // Show coordinates and address on double-click
+  // Show coordinates and fictional location on double-click
   map.on('dblclick', async (e) => {
     const { lat, lng } = e.latlng;
-    try {
-      const res = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`);
-      const data = await res.json();
-      const address = data.display_name || 'Address not found';
-      L.popup()
-        .setLatLng([lat, lng])
-        .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address:</b> ${address}`)
-        .openOn(map);
-    } catch (err) {
-      console.error('Reverse geocoding failed:', err);
-      L.popup()
-        .setLatLng([lat, lng])
-        .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address lookup failed.</b>`)
-        .openOn(map);
-    }
+    const locationName = getFictionalLocationName(lat, lng);
+    L.popup()
+      .setLatLng([lat, lng])
+      .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Location:</b> ${locationName}`)
+      .openOn(map);
   });
 
   return { map, gridSystem }; 

--- a/js/markerWithAddress.js
+++ b/js/markerWithAddress.js
@@ -1,6 +1,7 @@
 import { showPopup } from "./surveyPointPopup.js";
 import { showStreetViewPanel } from "./streetview.js";
 import { openCamera } from "./camera.js";
+import { getFictionalLocationName } from "./fictionalLocation.js";
 
 export function addMarkerWithAddress(lat, lng, map) {
   const icon = L.icon({
@@ -12,20 +13,15 @@ export function addMarkerWithAddress(lat, lng, map) {
   });
 
   const marker = L.marker([lat, lng], { icon }).addTo(map);
-  fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`)
-    .then((res) => res.json())
-    .then((data) => {
-      const address = data.display_name;
-      marker
-        .bindPopup(`
-          <b>Address:</b> ${address}<br>
-          <button class="sidebar-button" onclick="showPopup(${lat}, ${lng}, '${address.replace(/'/g, "\\'")}')">Add a Point Here</button>
-          <button class="sidebar-button" onclick="showStreetViewPanel(${lat}, ${lng})">View Street View</button>
-          <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Take Photo</button>
-        `)
-        .openPopup();
-    })
-    .catch((err) => console.error("Error reverse-geocoding:", err));
+  const locationName = getFictionalLocationName(lat, lng);
+  marker
+    .bindPopup(`
+      <b>Location:</b> ${locationName}<br>
+      <button class="sidebar-button" onclick="showPopup(${lat}, ${lng}, '${locationName.replace(/'/g, "\\'")}')">Add a Point Here</button>
+      <button class="sidebar-button" onclick="showStreetViewPanel(${lat}, ${lng})">View Street View</button>
+      <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Take Photo</button>
+    `)
+    .openPopup();
 }
 
 export function initMarkerWithAddress(map) {

--- a/js/poiModal.js
+++ b/js/poiModal.js
@@ -1,4 +1,5 @@
 // Handles the Point of Interest (POI) Modal functionality
+import { getFictionalLocationName } from './fictionalLocation.js';
 
 let placingPOI = false;
 let poiLatLng = { lat: null, lng: null };
@@ -37,23 +38,12 @@ function onMapClick(e) {
     const poiTitleInput = document.getElementById("poi-title");
     const poiDescInput = document.getElementById("poi-description");
 
-    fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${e.latlng.lat}&lon=${e.latlng.lng}`)
-        .then(res => res.json())
-        .then(data => {
-            poiAddress = data.display_name || "Address not found";
-            if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
-            if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
-            if (poiTitleInput) poiTitleInput.value = "";
-            if (poiDescInput) poiDescInput.value = "";
-            if (poiModal) poiModal.classList.add("active");
-        })
-        .catch(err => {
-            console.error("Error reverse geocoding for POI:", err);
-            poiAddress = "Address lookup failed";
-            if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
-            if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
-            if (poiModal) poiModal.classList.add("active");
-        });
+    poiAddress = getFictionalLocationName(e.latlng.lat, e.latlng.lng);
+    if (poiAddressEl) poiAddressEl.textContent = `Location: ${poiAddress}`;
+    if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
+    if (poiTitleInput) poiTitleInput.value = "";
+    if (poiDescInput) poiDescInput.value = "";
+    if (poiModal) poiModal.classList.add("active");
 }
 
 export function initPoiModal(map) {

--- a/js/surveyPointPopup.js
+++ b/js/surveyPointPopup.js
@@ -15,7 +15,7 @@ export function showPopup(lat, lng, address) {
     const pointTypeSelectInSidebar = document.querySelector("#right-sidebar #point-type-select");
 
     if (popupModule && geocodedAddressEl && coordinatesEl) {
-        geocodedAddressEl.textContent = `Address: ${address}`;
+        geocodedAddressEl.textContent = `Location: ${address}`;
         coordinatesEl.textContent = `Coordinates: ${lat.toFixed(6)}, ${lng.toFixed(6)}`;
 
         if (pointTypeSelectInPopup && pointTypeSelectInSidebar) {

--- a/js/tutorial/index.js
+++ b/js/tutorial/index.js
@@ -1,7 +1,7 @@
 const tutorialSteps = [
   { title: 'Welcome & Home Base', text: 'Click the home marker to open the Home Base Command Center.' },
   { title: 'Toolbar Overview', text: 'Use the toolbar to access factions, rules, grid scanning and more.' },
-  { title: 'Map Interaction', text: 'Double-click anywhere on the map to see coordinates and address.' },
+  { title: 'Map Interaction', text: 'Double-click anywhere on the map to see coordinates and a fictional location name.' },
   { title: 'Grid Toggle', text: 'Press the G key to toggle the map grid overlay.' },
   { title: 'Scanning', text: 'Select a grid cell and click Scan to inspect a 5x5 subgrid.' },
   { title: 'Mapping Roads', text: 'After scanning, click Map to retrieve major roads in the selected area.' },


### PR DESCRIPTION
## Summary
- generate deterministic fictional location names
- replace geocoding calls with fictional names
- rename address labels to `Location`
- update tutorial and GDD text
- register new module in import map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68472021132883329a092f9becacc424