### PR TITLE
Hide event addresses from player UI

### DIFF
--- a/js/eventFinder.js
+++ b/js/eventFinder.js
@@ -38,7 +38,7 @@ export function startEvent(eventId, eventTitle, eventAddress, eventLat, eventLng
   console.log(`Starting event: ${eventId} - ${eventTitle} at ${eventAddress}`);
   const latText = eventLat !== undefined ? eventLat.toFixed(6) : 'N/A';
   const lngText = eventLng !== undefined ? eventLng.toFixed(6) : 'N/A';
-  alert(`Launching event: ${eventTitle}\nLocation: ${eventAddress}\nCoordinates: ${latText}, ${lngText}`);
+  alert(`Launching event: ${eventTitle}\nCoordinates: ${latText}, ${lngText}`);
 }
 // Make available globally for any UI callbacks
 window.startEvent = startEvent;
@@ -134,8 +134,8 @@ async function routeToEvent(eventId, eventLat, eventLng) {
     routeDistanceText = `Drawn Route: ${directDistanceKm} km (Direct Line)`;
   }
 
-  if (marker && eventData) { 
-      const popupContent = `<b>${eventData.title}</b><br>Location: ${eventData.address}<br>${routeDistanceText}<br>${airDistanceText}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventData.title.replace(/'/g, "\\'")}', '${eventData.address.replace(/'/g, "\\'")}', ${eventLat}, ${eventLng})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${eventLat}, ${eventLng})">Route to Event</button>`;
+  if (marker && eventData) {
+      const popupContent = `<b>${eventData.title}</b><br>${routeDistanceText}<br>${airDistanceText}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventData.title.replace(/'/g, "\\'")}', '${eventData.address.replace(/'/g, "\\'")}', ${eventLat}, ${eventLng})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${eventLat}, ${eventLng})">Route to Event</button>`;
       marker.setPopupContent(popupContent);
       if (!marker.isPopupOpen()) {
           marker.openPopup();
@@ -251,7 +251,7 @@ export function initEventFinder(map) {
           const eventId = `event-${Date.now()}-${i}`; 
   
           const marker = L.marker(latLng, { icon: eventIcon })
-            .bindPopup(`<b>${eventTitle}</b><br>Location: ${address}<br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventTitle.replace(/'/g, "\\'")}', '${address.replace(/'/g, "\\'")}', ${latLng[0]}, ${latLng[1]})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${latLng[0]}, ${latLng[1]})">Route to Event</button>`);
+            .bindPopup(`<b>${eventTitle}</b><br><button class="sidebar-button" onclick="window.openPrepareEventModal('${eventId}', '${eventTitle.replace(/'/g, "\\'")}', '${address.replace(/'/g, "\\'")}', ${latLng[0]}, ${latLng[1]})">Prepare</button><button class="sidebar-button" onclick="routeToEvent('${eventId}', ${latLng[0]}, ${latLng[1]})">Route to Event</button>`);
           
           marker.eventId = eventId; // Store eventId on the marker
           marker.addTo(eventLayerGroup);

--- a/js/prepareEventModal/core/modalCore.js
+++ b/js/prepareEventModal/core/modalCore.js
@@ -173,22 +173,20 @@ function updateBriefingTabWithEventDetails() {
     const tabContent = modalElement.querySelector('#tab3-content');
     if(!tabContent) return;
 
-    const { eventId, eventTitle, eventAddress, eventLat, eventLng } = currentEventDetails;
+    const { eventId, eventTitle, eventLat, eventLng } = currentEventDetails;
     
     const briefingEventTitle = tabContent.querySelector('#briefing-event-title');
     const briefingEventIdSpan = tabContent.querySelector('#briefing-eventId');
-    const briefingEventAddressSpan = tabContent.querySelector('#briefing-eventAddress');
     const briefingEventCoordsSpan = tabContent.querySelector('#briefing-eventCoords');
 
     if (briefingEventTitle) briefingEventTitle.textContent = eventTitle;
     if (briefingEventIdSpan) briefingEventIdSpan.textContent = eventId;
-    if (briefingEventAddressSpan) briefingEventAddressSpan.textContent = eventAddress;
     if (briefingEventCoordsSpan) {
         briefingEventCoordsSpan.textContent = (eventLat && eventLng) ? `${eventLat.toFixed(6)}, ${eventLng.toFixed(6)}` : 'N/A';
     }
     
     const briefingTacticalOverview = tabContent.querySelector('#briefing-tactical-overview');
-    if (briefingTacticalOverview) briefingTacticalOverview.textContent = `Investigate disturbance at ${eventAddress}. Potential hostile contact. Proceed with caution.`;
+    if (briefingTacticalOverview) briefingTacticalOverview.textContent = 'Investigate disturbance in the target area. Potential hostile contact. Proceed with caution.';
     
     const briefingPotentialThreats = tabContent.querySelector('#briefing-potential-threats');
     if (briefingPotentialThreats) briefingPotentialThreats.textContent = `Threat level unknown. Primary concern is securing the area and gathering intel. Secondary: Identify hostile forces.`;

--- a/js/prepareEventModal/tabs/briefingTab.js
+++ b/js/prepareEventModal/tabs/briefingTab.js
@@ -10,7 +10,6 @@ export async function initBriefingTab(tabElement) {
             <div class="briefing-main-details">
                 <h3>Mission Briefing: <span id="briefing-event-title">N/A</span></h3>
                 <p><strong>Event ID:</strong> <span id="briefing-eventId">N/A</span></p>
-                <p><strong>Location:</strong> <span id="briefing-eventAddress">N/A</span></p>
                 <p><strong>Coordinates:</strong> <span id="briefing-eventCoords">N/A</span></p>
             </div>
     
@@ -64,24 +63,22 @@ export async function initBriefingTab(tabElement) {
 
 // Helper function to update briefing tab content with event details
 function updateBriefingWithEventDetails(tabElement, eventDetails) {
-    const { eventId, eventTitle, eventAddress, eventLat, eventLng } = eventDetails;
+    const { eventId, eventTitle, eventLat, eventLng } = eventDetails;
     
     const briefingEventTitle = tabElement.querySelector('#briefing-event-title');
     const briefingEventIdSpan = tabElement.querySelector('#briefing-eventId');
-    const briefingEventAddressSpan = tabElement.querySelector('#briefing-eventAddress');
     const briefingEventCoordsSpan = tabElement.querySelector('#briefing-eventCoords');
 
     if (briefingEventTitle) briefingEventTitle.textContent = eventTitle;
     if (briefingEventIdSpan) briefingEventIdSpan.textContent = eventId;
-    if (briefingEventAddressSpan) briefingEventAddressSpan.textContent = eventAddress;
     if (briefingEventCoordsSpan) {
-        briefingEventCoordsSpan.textContent = (eventLat && eventLng) ? 
+        briefingEventCoordsSpan.textContent = (eventLat && eventLng) ?
             `${eventLat.toFixed(6)}, ${eventLng.toFixed(6)}` : 'N/A';
     }
 
     const briefingTacticalOverview = tabElement.querySelector('#briefing-tactical-overview');
     if (briefingTacticalOverview) {
-        briefingTacticalOverview.textContent = 
-            `Investigate disturbance at ${eventAddress}. Potential hostile contact. Proceed with caution.`;
+        briefingTacticalOverview.textContent =
+            'Investigate disturbance in the target area. Potential hostile contact. Proceed with caution.';
     }
 }


### PR DESCRIPTION
## Summary
- strip event address from popups and alerts
- remove address from mission briefing tab
- keep address data internally for dev use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847262f9f008332be536050037177cf