### PR TITLE
Toggle real address resolution with DEV_MODE

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,11 @@ import { initScreenRecorder } from "./screenRecorder.js";
 import { initUI } from "./ui.js";
 import { initAuthModal } from "./authModal.js";
 
+// Global development flag
+if (window.DEV_MODE === undefined) {
+  window.DEV_MODE = false;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // Give React a chance to hydrate the page first
   setTimeout(() => { 

--- a/js/map.js
+++ b/js/map.js
@@ -6,6 +6,7 @@ import { initTerraIncognita } from "./terraIncognita.js";
 import { initWestOverlay } from "./westOverlay.js";
 import { initEastOverlay } from "./eastOverlay.js";
 import { initDMZOverlay } from "./dmzOverlay.js";
+import { getFictionalLocationName } from "./fictionalLocation.js";
 
 function initMap() {
   const map = initMapBase();
@@ -20,19 +21,28 @@ function initMap() {
   // Show coordinates and address on double-click
   map.on('dblclick', async (e) => {
     const { lat, lng } = e.latlng;
-    try {
-      const res = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`);
-      const data = await res.json();
-      const address = data.display_name || 'Address not found';
+    if (window.DEV_MODE) {
+      try {
+        const res = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`);
+        const data = await res.json();
+        const address = data.display_name || 'Address not found';
+        console.log('Double-click address:', address);
+        L.popup()
+          .setLatLng([lat, lng])
+          .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address:</b> ${address}`)
+          .openOn(map);
+      } catch (err) {
+        console.error('Reverse geocoding failed:', err);
+        L.popup()
+          .setLatLng([lat, lng])
+          .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address lookup failed.</b>`)
+          .openOn(map);
+      }
+    } else {
+      const fakeAddress = getFictionalLocationName(lat, lng);
       L.popup()
         .setLatLng([lat, lng])
-        .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address:</b> ${address}`)
-        .openOn(map);
-    } catch (err) {
-      console.error('Reverse geocoding failed:', err);
-      L.popup()
-        .setLatLng([lat, lng])
-        .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Address lookup failed.</b>`)
+        .setContent(`<b>Coordinates:</b> ${lat.toFixed(6)}, ${lng.toFixed(6)}<br><b>Location:</b> ${fakeAddress}`)
         .openOn(map);
     }
   });

--- a/js/markerWithAddress.js
+++ b/js/markerWithAddress.js
@@ -1,6 +1,7 @@
 import { showPopup } from "./surveyPointPopup.js";
 import { showStreetViewPanel } from "./streetview.js";
 import { openCamera } from "./camera.js";
+import { getFictionalLocationName } from "./fictionalLocation.js";
 
 export function addMarkerWithAddress(lat, lng, map) {
   const icon = L.icon({
@@ -12,20 +13,33 @@ export function addMarkerWithAddress(lat, lng, map) {
   });
 
   const marker = L.marker([lat, lng], { icon }).addTo(map);
-  fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`)
-    .then((res) => res.json())
-    .then((data) => {
-      const address = data.display_name;
-      marker
-        .bindPopup(`
-          <b>Address:</b> ${address}<br>
-          <button class="sidebar-button" onclick="showPopup(${lat}, ${lng}, '${address.replace(/'/g, "\\'")}')">Add a Point Here</button>
-          <button class="sidebar-button" onclick="showStreetViewPanel(${lat}, ${lng})">View Street View</button>
-          <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Take Photo</button>
-        `)
-        .openPopup();
-    })
-    .catch((err) => console.error("Error reverse-geocoding:", err));
+  if (window.DEV_MODE) {
+    fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`)
+      .then((res) => res.json())
+      .then((data) => {
+        const address = data.display_name;
+        console.log('Marker address:', address);
+        marker
+          .bindPopup(`
+            <b>Address:</b> ${address}<br>
+            <button class="sidebar-button" onclick="showPopup(${lat}, ${lng}, '${address.replace(/'/g, "\\'")}')">Add a Point Here</button>
+            <button class="sidebar-button" onclick="showStreetViewPanel(${lat}, ${lng})">View Street View</button>
+            <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Take Photo</button>
+          `)
+          .openPopup();
+      })
+      .catch((err) => console.error('Error reverse-geocoding:', err));
+  } else {
+    const address = getFictionalLocationName(lat, lng);
+    marker
+      .bindPopup(`
+        <b>Location:</b> ${address}<br>
+        <button class="sidebar-button" onclick="showPopup(${lat}, ${lng}, '${address.replace(/'/g, "\\'")}')">Add a Point Here</button>
+        <button class="sidebar-button" onclick="showStreetViewPanel(${lat}, ${lng})">View Street View</button>
+        <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Take Photo</button>
+      `)
+      .openPopup();
+  }
 }
 
 export function initMarkerWithAddress(map) {

--- a/js/poiModal.js
+++ b/js/poiModal.js
@@ -4,6 +4,7 @@ let placingPOI = false;
 let poiLatLng = { lat: null, lng: null };
 let poiAddress = "";
 let mapInstance; // To store the map reference
+import { getFictionalLocationName } from "./fictionalLocation.js";
 
 const flagIcon = L.icon({
     iconUrl: "/icons/flag-cursor.png", 
@@ -37,23 +38,33 @@ function onMapClick(e) {
     const poiTitleInput = document.getElementById("poi-title");
     const poiDescInput = document.getElementById("poi-description");
 
-    fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${e.latlng.lat}&lon=${e.latlng.lng}`)
-        .then(res => res.json())
-        .then(data => {
-            poiAddress = data.display_name || "Address not found";
-            if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
-            if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
-            if (poiTitleInput) poiTitleInput.value = "";
-            if (poiDescInput) poiDescInput.value = "";
-            if (poiModal) poiModal.classList.add("active");
-        })
-        .catch(err => {
-            console.error("Error reverse geocoding for POI:", err);
-            poiAddress = "Address lookup failed";
-            if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
-            if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
-            if (poiModal) poiModal.classList.add("active");
-        });
+    if (window.DEV_MODE) {
+        fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${e.latlng.lat}&lon=${e.latlng.lng}`)
+            .then(res => res.json())
+            .then(data => {
+                poiAddress = data.display_name || "Address not found";
+                console.log('POI address:', poiAddress);
+                if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
+                if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
+                if (poiTitleInput) poiTitleInput.value = "";
+                if (poiDescInput) poiDescInput.value = "";
+                if (poiModal) poiModal.classList.add("active");
+            })
+            .catch(err => {
+                console.error("Error reverse geocoding for POI:", err);
+                poiAddress = "Address lookup failed";
+                if (poiAddressEl) poiAddressEl.textContent = `Address: ${poiAddress}`;
+                if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
+                if (poiModal) poiModal.classList.add("active");
+            });
+    } else {
+        poiAddress = getFictionalLocationName(e.latlng.lat, e.latlng.lng);
+        if (poiAddressEl) poiAddressEl.textContent = `Location: ${poiAddress}`;
+        if (poiCoordinatesEl) poiCoordinatesEl.textContent = `Coordinates: ${e.latlng.lat.toFixed(6)}, ${e.latlng.lng.toFixed(6)}`;
+        if (poiTitleInput) poiTitleInput.value = "";
+        if (poiDescInput) poiDescInput.value = "";
+        if (poiModal) poiModal.classList.add("active");
+    }
 }
 
 export function initPoiModal(map) {

--- a/js/surveyPointPopup (1).js
+++ b/js/surveyPointPopup (1).js
@@ -1,5 +1,7 @@
 // Handles the "Add Survey Point" Popup Module
 
+import { getFictionalLocationName } from "./fictionalLocation.js";
+
 function hidePopup() {
     const popup = document.getElementById("popup-module");
     if (popup) {
@@ -15,7 +17,8 @@ export function showPopup(lat, lng, address) {
     const pointTypeSelectInSidebar = document.querySelector("#right-sidebar #point-type-select");
 
     if (popupModule && geocodedAddressEl && coordinatesEl) {
-        geocodedAddressEl.textContent = `Location: ${address}`;
+        const displayAddress = window.DEV_MODE ? `Address: ${address}` : `Location: ${getFictionalLocationName(lat, lng)}`;
+        geocodedAddressEl.textContent = displayAddress;
         coordinatesEl.textContent = `Coordinates: ${lat.toFixed(6)}, ${lng.toFixed(6)}`;
 
         if (pointTypeSelectInPopup && pointTypeSelectInSidebar) {

--- a/js/surveyPointPopup.js
+++ b/js/surveyPointPopup.js
@@ -1,5 +1,7 @@
 // Handles the "Add Survey Point" Popup Module
 
+import { getFictionalLocationName } from "./fictionalLocation.js";
+
 function hidePopup() {
     const popup = document.getElementById("popup-module");
     if (popup) {
@@ -15,7 +17,8 @@ export function showPopup(lat, lng, address) {
     const pointTypeSelectInSidebar = document.querySelector("#right-sidebar #point-type-select");
 
     if (popupModule && geocodedAddressEl && coordinatesEl) {
-        geocodedAddressEl.textContent = `Address: ${address}`;
+        const displayAddress = window.DEV_MODE ? `Address: ${address}` : `Location: ${getFictionalLocationName(lat, lng)}`;
+        geocodedAddressEl.textContent = displayAddress;
         coordinatesEl.textContent = `Coordinates: ${lat.toFixed(6)}, ${lng.toFixed(6)}`;
 
         if (pointTypeSelectInPopup && pointTypeSelectInSidebar) {


### PR DESCRIPTION
## Summary
- add global `DEV_MODE` flag
- resolve addresses only when `DEV_MODE` is true
- generate fictional location names otherwise
- update address displays across popups and modals

## Testing
- `node --version`
- `apt-cache policy apt-utils | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68472e709b8c8332868ac2f53ed4b624