### PR TITLE
Add alt attributes in camera.js

### DIFF
--- a/devlog.md
+++ b/devlog.md
@@ -4,3 +4,4 @@ This log tracks notable repository updates for contributors.
 
 - 2025-06-10: Created devlog with introductory section.
 - 2025-06-11: Added JSDoc comments for exported functions.
+- 2025-06-12: Added alt attributes to images captured by camera.js.

--- a/js/camera.js
+++ b/js/camera.js
@@ -10,13 +10,14 @@ function openCamera(lat, lng) {
       reader.onload = (event) => {
         const img = document.createElement("img");
         img.src = event.target.result;
+        img.alt = "Captured photo";
         img.style.maxWidth = "100%";
         img.style.height = "auto";
 
         L.popup()
           .setLatLng([lat, lng])
           .setContent(`
-            <img src="${event.target.result}" style="max-width: 100%; height: auto;">
+            <img src="${event.target.result}" alt="Captured photo" style="max-width: 100%; height: auto;">
             <button class="camera-btn" onclick="openCamera(${lat}, ${lng})">📷 Retake Photo</button>
           `)
           .openOn(window.mapInstance);
@@ -25,10 +26,12 @@ function openCamera(lat, lng) {
         const existingImage = document.getElementById("captured-image");
         if (existingImage) {
           existingImage.src = event.target.result;
+          existingImage.alt = "Captured photo";
         } else {
           const newImage = document.createElement("img");
           newImage.id = "captured-image";
           newImage.src = event.target.result;
+          newImage.alt = "Captured photo";
           streetViewPanel.appendChild(newImage);
         }
       };


### PR DESCRIPTION
## Summary
- ensure captured images include descriptive `alt` text
- log update in devlog

## Testing
- `node test_camera.js`

------
https://chatgpt.com/codex/tasks/task_e_684874a272708332945f3f838efac2a4