### PR TITLE
Add lock file split script

### DIFF
--- a/devlog.md
+++ b/devlog.md
@@ -6,3 +6,4 @@ This log tracks notable repository updates for contributors.
 - 2025-06-11: Added JSDoc comments for exported functions.
 - 2025-06-12: Added alt attributes to images captured by camera.js.
 - 2025-06-13: Initialized package.json, installed ESLint and added lint script.
+- 2025-06-10: Added split-lock script to break package-lock.json into smaller files.

--- a/package-lock-split/node_modules_@eslint-community_eslint-utils.json
+++ b/package-lock-split/node_modules_@eslint-community_eslint-utils.json
@@ -1,0 +1,19 @@
+{
+  "version": "4.7.0",
+  "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+  "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "eslint-visitor-keys": "^3.4.3"
+  },
+  "engines": {
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  },
+  "peerDependencies": {
+    "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint-community_eslint-utils_node_modules_eslint-visitor-keys.json
+++ b/package-lock-split/node_modules_@eslint-community_eslint-utils_node_modules_eslint-visitor-keys.json
@@ -1,0 +1,13 @@
+{
+  "version": "3.4.3",
+  "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+  "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  }
+}

--- a/package-lock-split/node_modules_@eslint-community_regexpp.json
+++ b/package-lock-split/node_modules_@eslint-community_regexpp.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.12.1",
+  "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+  "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_config-array.json
+++ b/package-lock-split/node_modules_@eslint_config-array.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.20.0",
+  "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+  "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@eslint/object-schema": "^2.1.6",
+    "debug": "^4.3.1",
+    "minimatch": "^3.1.2"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_config-helpers.json
+++ b/package-lock-split/node_modules_@eslint_config-helpers.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.2.2",
+  "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+  "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_core.json
+++ b/package-lock-split/node_modules_@eslint_core.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.14.0",
+  "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+  "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@types/json-schema": "^7.0.15"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_eslintrc.json
+++ b/package-lock-split/node_modules_@eslint_eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "version": "3.3.1",
+  "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+  "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "ajv": "^6.12.4",
+    "debug": "^4.3.2",
+    "espree": "^10.0.1",
+    "globals": "^14.0.0",
+    "ignore": "^5.2.0",
+    "import-fresh": "^3.2.1",
+    "js-yaml": "^4.1.0",
+    "minimatch": "^3.1.2",
+    "strip-json-comments": "^3.1.1"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_js.json
+++ b/package-lock-split/node_modules_@eslint_js.json
@@ -1,0 +1,13 @@
+{
+  "version": "9.28.0",
+  "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+  "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://eslint.org/donate"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_object-schema.json
+++ b/package-lock-split/node_modules_@eslint_object-schema.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.1.6",
+  "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+  "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  }
+}

--- a/package-lock-split/node_modules_@eslint_plugin-kit.json
+++ b/package-lock-split/node_modules_@eslint_plugin-kit.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.3.1",
+  "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+  "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@eslint/core": "^0.14.0",
+    "levn": "^0.4.1"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  }
+}

--- a/package-lock-split/node_modules_@humanfs_core.json
+++ b/package-lock-split/node_modules_@humanfs_core.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.19.1",
+  "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+  "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18.18.0"
+  }
+}

--- a/package-lock-split/node_modules_@humanfs_node.json
+++ b/package-lock-split/node_modules_@humanfs_node.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.16.6",
+  "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+  "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@humanfs/core": "^0.19.1",
+    "@humanwhocodes/retry": "^0.3.0"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  }
+}

--- a/package-lock-split/node_modules_@humanfs_node_node_modules_@humanwhocodes_retry.json
+++ b/package-lock-split/node_modules_@humanfs_node_node_modules_@humanwhocodes_retry.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.3.1",
+  "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+  "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18.18"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/nzakas"
+  }
+}

--- a/package-lock-split/node_modules_@humanwhocodes_module-importer.json
+++ b/package-lock-split/node_modules_@humanwhocodes_module-importer.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0.1",
+  "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+  "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=12.22"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/nzakas"
+  }
+}

--- a/package-lock-split/node_modules_@humanwhocodes_retry.json
+++ b/package-lock-split/node_modules_@humanwhocodes_retry.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.4.3",
+  "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+  "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18.18"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/nzakas"
+  }
+}

--- a/package-lock-split/node_modules_@types_estree.json
+++ b/package-lock-split/node_modules_@types_estree.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.8",
+  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+  "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_@types_json-schema.json
+++ b/package-lock-split/node_modules_@types_json-schema.json
@@ -1,0 +1,7 @@
+{
+  "version": "7.0.15",
+  "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+  "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_acorn-jsx.json
+++ b/package-lock-split/node_modules_acorn-jsx.json
@@ -1,0 +1,10 @@
+{
+  "version": "5.3.2",
+  "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+  "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+  "dev": true,
+  "license": "MIT",
+  "peerDependencies": {
+    "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+  }
+}

--- a/package-lock-split/node_modules_acorn.json
+++ b/package-lock-split/node_modules_acorn.json
@@ -1,0 +1,13 @@
+{
+  "version": "8.15.0",
+  "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+  "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+  "dev": true,
+  "license": "MIT",
+  "bin": {
+    "acorn": "bin/acorn"
+  },
+  "engines": {
+    "node": ">=0.4.0"
+  }
+}

--- a/package-lock-split/node_modules_ajv.json
+++ b/package-lock-split/node_modules_ajv.json
@@ -1,0 +1,17 @@
+{
+  "version": "6.12.6",
+  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+  "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "fast-deep-equal": "^3.1.1",
+    "fast-json-stable-stringify": "^2.0.0",
+    "json-schema-traverse": "^0.4.1",
+    "uri-js": "^4.2.2"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/epoberezkin"
+  }
+}

--- a/package-lock-split/node_modules_ansi-styles.json
+++ b/package-lock-split/node_modules_ansi-styles.json
@@ -1,0 +1,16 @@
+{
+  "version": "4.3.0",
+  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+  "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "color-convert": "^2.0.1"
+  },
+  "engines": {
+    "node": ">=8"
+  },
+  "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+  }
+}

--- a/package-lock-split/node_modules_argparse.json
+++ b/package-lock-split/node_modules_argparse.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0.1",
+  "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+  "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+  "dev": true,
+  "license": "Python-2.0"
+}

--- a/package-lock-split/node_modules_balanced-match.json
+++ b/package-lock-split/node_modules_balanced-match.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.2",
+  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+  "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_brace-expansion.json
+++ b/package-lock-split/node_modules_brace-expansion.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.11",
+  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+  }
+}

--- a/package-lock-split/node_modules_callsites.json
+++ b/package-lock-split/node_modules_callsites.json
@@ -1,0 +1,10 @@
+{
+  "version": "3.1.0",
+  "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+  "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/package-lock-split/node_modules_chalk.json
+++ b/package-lock-split/node_modules_chalk.json
@@ -1,0 +1,17 @@
+{
+  "version": "4.1.2",
+  "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+  "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "ansi-styles": "^4.1.0",
+    "supports-color": "^7.1.0"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+  }
+}

--- a/package-lock-split/node_modules_color-convert.json
+++ b/package-lock-split/node_modules_color-convert.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.1",
+  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "color-name": "~1.1.4"
+  },
+  "engines": {
+    "node": ">=7.0.0"
+  }
+}

--- a/package-lock-split/node_modules_color-name.json
+++ b/package-lock-split/node_modules_color-name.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.1.4",
+  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_concat-map.json
+++ b/package-lock-split/node_modules_concat-map.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.0.1",
+  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+  "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_cross-spawn.json
+++ b/package-lock-split/node_modules_cross-spawn.json
@@ -1,0 +1,15 @@
+{
+  "version": "7.0.6",
+  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+  "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "path-key": "^3.1.0",
+    "shebang-command": "^2.0.0",
+    "which": "^2.0.1"
+  },
+  "engines": {
+    "node": ">= 8"
+  }
+}

--- a/package-lock-split/node_modules_debug.json
+++ b/package-lock-split/node_modules_debug.json
@@ -1,0 +1,18 @@
+{
+  "version": "4.4.1",
+  "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+  "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "ms": "^2.1.3"
+  },
+  "engines": {
+    "node": ">=6.0"
+  },
+  "peerDependenciesMeta": {
+    "supports-color": {
+      "optional": true
+    }
+  }
+}

--- a/package-lock-split/node_modules_deep-is.json
+++ b/package-lock-split/node_modules_deep-is.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.1.4",
+  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+  "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_escape-string-regexp.json
+++ b/package-lock-split/node_modules_escape-string-regexp.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.0.0",
+  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+  "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_eslint-scope.json
+++ b/package-lock-split/node_modules_eslint-scope.json
@@ -1,0 +1,17 @@
+{
+  "version": "8.4.0",
+  "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+  "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "esrecurse": "^4.3.0",
+    "estraverse": "^5.2.0"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  }
+}

--- a/package-lock-split/node_modules_eslint-visitor-keys.json
+++ b/package-lock-split/node_modules_eslint-visitor-keys.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.2.1",
+  "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+  "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+  "dev": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  }
+}

--- a/package-lock-split/node_modules_eslint.json
+++ b/package-lock-split/node_modules_eslint.json
@@ -1,0 +1,61 @@
+{
+  "version": "9.28.0",
+  "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+  "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "@eslint-community/eslint-utils": "^4.2.0",
+    "@eslint-community/regexpp": "^4.12.1",
+    "@eslint/config-array": "^0.20.0",
+    "@eslint/config-helpers": "^0.2.1",
+    "@eslint/core": "^0.14.0",
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "9.28.0",
+    "@eslint/plugin-kit": "^0.3.1",
+    "@humanfs/node": "^0.16.6",
+    "@humanwhocodes/module-importer": "^1.0.1",
+    "@humanwhocodes/retry": "^0.4.2",
+    "@types/estree": "^1.0.6",
+    "@types/json-schema": "^7.0.15",
+    "ajv": "^6.12.4",
+    "chalk": "^4.0.0",
+    "cross-spawn": "^7.0.6",
+    "debug": "^4.3.2",
+    "escape-string-regexp": "^4.0.0",
+    "eslint-scope": "^8.3.0",
+    "eslint-visitor-keys": "^4.2.0",
+    "espree": "^10.3.0",
+    "esquery": "^1.5.0",
+    "esutils": "^2.0.2",
+    "fast-deep-equal": "^3.1.3",
+    "file-entry-cache": "^8.0.0",
+    "find-up": "^5.0.0",
+    "glob-parent": "^6.0.2",
+    "ignore": "^5.2.0",
+    "imurmurhash": "^0.1.4",
+    "is-glob": "^4.0.0",
+    "json-stable-stringify-without-jsonify": "^1.0.1",
+    "lodash.merge": "^4.6.2",
+    "minimatch": "^3.1.2",
+    "natural-compare": "^1.4.0",
+    "optionator": "^0.9.3"
+  },
+  "bin": {
+    "eslint": "bin/eslint.js"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://eslint.org/donate"
+  },
+  "peerDependencies": {
+    "jiti": "*"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
+  }
+}

--- a/package-lock-split/node_modules_espree.json
+++ b/package-lock-split/node_modules_espree.json
@@ -1,0 +1,18 @@
+{
+  "version": "10.4.0",
+  "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+  "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "acorn": "^8.15.0",
+    "acorn-jsx": "^5.3.2",
+    "eslint-visitor-keys": "^4.2.1"
+  },
+  "engines": {
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+  },
+  "funding": {
+    "url": "https://opencollective.com/eslint"
+  }
+}

--- a/package-lock-split/node_modules_esquery.json
+++ b/package-lock-split/node_modules_esquery.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.6.0",
+  "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+  "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+  "dev": true,
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "estraverse": "^5.1.0"
+  },
+  "engines": {
+    "node": ">=0.10"
+  }
+}

--- a/package-lock-split/node_modules_esrecurse.json
+++ b/package-lock-split/node_modules_esrecurse.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.3.0",
+  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+  "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "estraverse": "^5.2.0"
+  },
+  "engines": {
+    "node": ">=4.0"
+  }
+}

--- a/package-lock-split/node_modules_estraverse.json
+++ b/package-lock-split/node_modules_estraverse.json
@@ -1,0 +1,10 @@
+{
+  "version": "5.3.0",
+  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+  "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "engines": {
+    "node": ">=4.0"
+  }
+}

--- a/package-lock-split/node_modules_esutils.json
+++ b/package-lock-split/node_modules_esutils.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0.3",
+  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+  "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}

--- a/package-lock-split/node_modules_fast-deep-equal.json
+++ b/package-lock-split/node_modules_fast-deep-equal.json
@@ -1,0 +1,7 @@
+{
+  "version": "3.1.3",
+  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+  "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_fast-json-stable-stringify.json
+++ b/package-lock-split/node_modules_fast-json-stable-stringify.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.1.0",
+  "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+  "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_fast-levenshtein.json
+++ b/package-lock-split/node_modules_fast-levenshtein.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0.6",
+  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+  "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_file-entry-cache.json
+++ b/package-lock-split/node_modules_file-entry-cache.json
@@ -1,0 +1,13 @@
+{
+  "version": "8.0.0",
+  "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+  "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "flat-cache": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/package-lock-split/node_modules_find-up.json
+++ b/package-lock-split/node_modules_find-up.json
@@ -1,0 +1,17 @@
+{
+  "version": "5.0.0",
+  "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+  "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "locate-path": "^6.0.0",
+    "path-exists": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_flat-cache.json
+++ b/package-lock-split/node_modules_flat-cache.json
@@ -1,0 +1,14 @@
+{
+  "version": "4.0.1",
+  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+  "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "flatted": "^3.2.9",
+    "keyv": "^4.5.4"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/package-lock-split/node_modules_flatted.json
+++ b/package-lock-split/node_modules_flatted.json
@@ -1,0 +1,7 @@
+{
+  "version": "3.3.3",
+  "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+  "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+  "dev": true,
+  "license": "ISC"
+}

--- a/package-lock-split/node_modules_glob-parent.json
+++ b/package-lock-split/node_modules_glob-parent.json
@@ -1,0 +1,13 @@
+{
+  "version": "6.0.2",
+  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+  "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+  "dev": true,
+  "license": "ISC",
+  "dependencies": {
+    "is-glob": "^4.0.3"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  }
+}

--- a/package-lock-split/node_modules_globals.json
+++ b/package-lock-split/node_modules_globals.json
@@ -1,0 +1,13 @@
+{
+  "version": "14.0.0",
+  "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+  "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_has-flag.json
+++ b/package-lock-split/node_modules_has-flag.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.0.0",
+  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+  "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_ignore.json
+++ b/package-lock-split/node_modules_ignore.json
@@ -1,0 +1,10 @@
+{
+  "version": "5.3.2",
+  "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+  "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">= 4"
+  }
+}

--- a/package-lock-split/node_modules_import-fresh.json
+++ b/package-lock-split/node_modules_import-fresh.json
@@ -1,0 +1,17 @@
+{
+  "version": "3.3.1",
+  "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+  "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "parent-module": "^1.0.0",
+    "resolve-from": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_imurmurhash.json
+++ b/package-lock-split/node_modules_imurmurhash.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.1.4",
+  "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+  "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.8.19"
+  }
+}

--- a/package-lock-split/node_modules_is-extglob.json
+++ b/package-lock-split/node_modules_is-extglob.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.1.1",
+  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+  "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}

--- a/package-lock-split/node_modules_is-glob.json
+++ b/package-lock-split/node_modules_is-glob.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.0.3",
+  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+  "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "is-extglob": "^2.1.1"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}

--- a/package-lock-split/node_modules_isexe.json
+++ b/package-lock-split/node_modules_isexe.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0.0",
+  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+  "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+  "dev": true,
+  "license": "ISC"
+}

--- a/package-lock-split/node_modules_js-yaml.json
+++ b/package-lock-split/node_modules_js-yaml.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.1.0",
+  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+  "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "argparse": "^2.0.1"
+  },
+  "bin": {
+    "js-yaml": "bin/js-yaml.js"
+  }
+}

--- a/package-lock-split/node_modules_json-buffer.json
+++ b/package-lock-split/node_modules_json-buffer.json
@@ -1,0 +1,7 @@
+{
+  "version": "3.0.1",
+  "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+  "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_json-schema-traverse.json
+++ b/package-lock-split/node_modules_json-schema-traverse.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.4.1",
+  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+  "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_json-stable-stringify-without-jsonify.json
+++ b/package-lock-split/node_modules_json-stable-stringify-without-jsonify.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.1",
+  "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+  "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_keyv.json
+++ b/package-lock-split/node_modules_keyv.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.5.4",
+  "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+  "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "json-buffer": "3.0.1"
+  }
+}

--- a/package-lock-split/node_modules_levn.json
+++ b/package-lock-split/node_modules_levn.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.4.1",
+  "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+  "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "prelude-ls": "^1.2.1",
+    "type-check": "~0.4.0"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  }
+}

--- a/package-lock-split/node_modules_locate-path.json
+++ b/package-lock-split/node_modules_locate-path.json
@@ -1,0 +1,16 @@
+{
+  "version": "6.0.0",
+  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+  "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "p-locate": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_lodash.merge.json
+++ b/package-lock-split/node_modules_lodash.merge.json
@@ -1,0 +1,7 @@
+{
+  "version": "4.6.2",
+  "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+  "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_minimatch.json
+++ b/package-lock-split/node_modules_minimatch.json
@@ -1,0 +1,13 @@
+{
+  "version": "3.1.2",
+  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+  "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+  "dev": true,
+  "license": "ISC",
+  "dependencies": {
+    "brace-expansion": "^1.1.7"
+  },
+  "engines": {
+    "node": "*"
+  }
+}

--- a/package-lock-split/node_modules_ms.json
+++ b/package-lock-split/node_modules_ms.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.1.3",
+  "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+  "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_natural-compare.json
+++ b/package-lock-split/node_modules_natural-compare.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.4.0",
+  "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+  "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+  "dev": true,
+  "license": "MIT"
+}

--- a/package-lock-split/node_modules_optionator.json
+++ b/package-lock-split/node_modules_optionator.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.9.4",
+  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+  "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "deep-is": "^0.1.3",
+    "fast-levenshtein": "^2.0.6",
+    "levn": "^0.4.1",
+    "prelude-ls": "^1.2.1",
+    "type-check": "^0.4.0",
+    "word-wrap": "^1.2.5"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  }
+}

--- a/package-lock-split/node_modules_p-limit.json
+++ b/package-lock-split/node_modules_p-limit.json
@@ -1,0 +1,16 @@
+{
+  "version": "3.1.0",
+  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+  "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "yocto-queue": "^0.1.0"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_p-locate.json
+++ b/package-lock-split/node_modules_p-locate.json
@@ -1,0 +1,16 @@
+{
+  "version": "5.0.0",
+  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+  "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "p-limit": "^3.0.2"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_parent-module.json
+++ b/package-lock-split/node_modules_parent-module.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.1",
+  "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+  "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "callsites": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/package-lock-split/node_modules_path-exists.json
+++ b/package-lock-split/node_modules_path-exists.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.0.0",
+  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+  "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_path-key.json
+++ b/package-lock-split/node_modules_path-key.json
@@ -1,0 +1,10 @@
+{
+  "version": "3.1.1",
+  "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+  "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_prelude-ls.json
+++ b/package-lock-split/node_modules_prelude-ls.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.2.1",
+  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+  "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">= 0.8.0"
+  }
+}

--- a/package-lock-split/node_modules_punycode.json
+++ b/package-lock-split/node_modules_punycode.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.3.1",
+  "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+  "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/package-lock-split/node_modules_resolve-from.json
+++ b/package-lock-split/node_modules_resolve-from.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.0.0",
+  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+  "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  }
+}

--- a/package-lock-split/node_modules_shebang-command.json
+++ b/package-lock-split/node_modules_shebang-command.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+  "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "shebang-regex": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_shebang-regex.json
+++ b/package-lock-split/node_modules_shebang-regex.json
@@ -1,0 +1,10 @@
+{
+  "version": "3.0.0",
+  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+  "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_strip-json-comments.json
+++ b/package-lock-split/node_modules_strip-json-comments.json
@@ -1,0 +1,13 @@
+{
+  "version": "3.1.1",
+  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+  "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/node_modules_supports-color.json
+++ b/package-lock-split/node_modules_supports-color.json
@@ -1,0 +1,13 @@
+{
+  "version": "7.2.0",
+  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+  "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "has-flag": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/package-lock-split/node_modules_type-check.json
+++ b/package-lock-split/node_modules_type-check.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.4.0",
+  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+  "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+  "dev": true,
+  "license": "MIT",
+  "dependencies": {
+    "prelude-ls": "^1.2.1"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  }
+}

--- a/package-lock-split/node_modules_uri-js.json
+++ b/package-lock-split/node_modules_uri-js.json
@@ -1,0 +1,10 @@
+{
+  "version": "4.4.1",
+  "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+  "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+  "dev": true,
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "punycode": "^2.1.0"
+  }
+}

--- a/package-lock-split/node_modules_which.json
+++ b/package-lock-split/node_modules_which.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.2",
+  "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+  "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+  "dev": true,
+  "license": "ISC",
+  "dependencies": {
+    "isexe": "^2.0.0"
+  },
+  "bin": {
+    "node-which": "bin/node-which"
+  },
+  "engines": {
+    "node": ">= 8"
+  }
+}

--- a/package-lock-split/node_modules_word-wrap.json
+++ b/package-lock-split/node_modules_word-wrap.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.2.5",
+  "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+  "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}

--- a/package-lock-split/node_modules_yocto-queue.json
+++ b/package-lock-split/node_modules_yocto-queue.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1.0",
+  "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+  "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+  "dev": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+  }
+}

--- a/package-lock-split/root.json
+++ b/package-lock-split/root.json
@@ -1,0 +1,8 @@
+{
+  "name": "testing",
+  "version": "1.0.0",
+  "license": "ISC",
+  "devDependencies": {
+    "eslint": "^9.28.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint js/**/*.js"
+    "lint": "eslint js/**/*.js",
+    "split-lock": "node scripts/split-lock.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/split-lock.js
+++ b/scripts/split-lock.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Split package-lock.json into individual package files for easier inspection.
+ * Files are written to the package-lock-split directory.
+ */
+function splitLock() {
+  const lockPath = path.join(process.cwd(), 'package-lock.json');
+  const lockData = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  const outDir = path.join(process.cwd(), 'package-lock-split');
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir);
+  }
+  const packages = lockData.packages || {};
+  for (const [pkgPath, pkgInfo] of Object.entries(packages)) {
+    const fileName = pkgPath === '' ? 'root.json' : `${pkgPath.replace(/[\\/]/g, '_')}.json`;
+    fs.writeFileSync(path.join(outDir, fileName), JSON.stringify(pkgInfo, null, 2));
+  }
+}
+
+splitLock();


### PR DESCRIPTION
## Summary
- add a script that splits `package-lock.json` into individual package files
- expose the script via `npm run split-lock`
- document the change in `devlog.md`

## Testing
- `npm run split-lock`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848a2824a108332a4b06ce749c44121