### PR TITLE
Revamp team and loadout UI

### DIFF
--- a/css/prepareEventModal/tabs/loadout-tab.css
+++ b/css/prepareEventModal/tabs/loadout-tab.css
@@ -150,4 +150,12 @@
 
 .equipment-list {
     margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.equipment-list .list-item-icon {
+    width: 50px;
+    height: 50px;
 }

--- a/css/prepareEventModal/tabs/team-tab.css
+++ b/css/prepareEventModal/tabs/team-tab.css
@@ -114,6 +114,14 @@
     margin-top: 10px;
     max-height: calc(100% - 40px);
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.available-units-list .list-item-icon {
+    width: 60px;
+    height: 60px;
 }
 
 .team-stats-panel {

--- a/devlog.md
+++ b/devlog.md
@@ -10,3 +10,4 @@ This log tracks notable repository updates for contributors.
 - 2025-06-14: Cleaned package-lock.json after splitting.
 
 - 2025-06-10: Updated team tab CSS to match markup.
+- 2025-06-10: Redesigned team and loadout tabs with uniform list items.

--- a/js/loadoutManager.js
+++ b/js/loadoutManager.js
@@ -78,15 +78,17 @@ function renderAvailableWeaponsList() {
 
     availableWeapons.forEach(weapon => {
         const weaponItem = document.createElement('div');
-        weaponItem.className = 'weapon-item-draggable';
+        weaponItem.className = 'list-item list-item-grid draggable';
         weaponItem.draggable = true;
         weaponItem.dataset.weaponId = weapon.id;
 
         weaponItem.innerHTML = `
-            <img src="${weapon.imagePath}" alt="${weapon.name}" onerror="this.style.display='none'; this.nextElementSibling.querySelector('strong').textContent += ' (Img Fail)';">
-            <div class="weapon-item-info">
-                <strong>${weapon.name}</strong>
-                <span>Dmg: ${weapon.std_dmg || 'N/A'}, Range: ${weapon.range_yd || weapon.range || 'N/A'}</span>
+            <div class="list-item-icon">
+                <img src="${weapon.imagePath}" alt="${weapon.name}" onerror="this.style.display='none';">
+            </div>
+            <div class="list-item-content">
+                <div class="list-item-title">${weapon.name}</div>
+                <div class="list-item-description">Dmg:${weapon.std_dmg || 'N/A'} Range:${weapon.range_yd || weapon.range || 'N/A'}</div>
             </div>
         `;
         weaponItem.addEventListener('dragstart', (event) => {

--- a/js/prepareEventModal/tabs/loadoutTab.js
+++ b/js/prepareEventModal/tabs/loadoutTab.js
@@ -11,7 +11,7 @@ export async function initLoadoutTab(tabElement) {
             <div id="selected-soldiers-loadouts" class="selected-soldiers-loadouts"></div>
             <div class="available-equipment-panel">
                 <h3>Available Weapons</h3>
-                <div id="available-weapons-list" class="equipment-list scrollable-list"></div>
+                <div id="available-weapons-list" class="equipment-list scrollable-list available-weapons-list"></div>
                 <h3>Available Armor</h3>
                 <div class="equipment-list"><p>Armor system coming soon.</p></div>
                 <h3>Available Items</h3>

--- a/js/prepareEventModal/tabs/teamTab.js
+++ b/js/prepareEventModal/tabs/teamTab.js
@@ -10,7 +10,7 @@ export async function initTeamTab(tabElement) {
         <div class="team-configuration-container">
             <div class="available-units-panel">
                 <h3>Available Units (FDG)</h3>
-                <div id="available-units-list" class="units-list scrollable-list"></div>
+                <div id="available-units-list" class="units-list scrollable-list available-units-list"></div>
             </div>
             <div class="active-team-panel">
                 <h3>Active Team (Max 3)</h3>

--- a/js/teamManager.js
+++ b/js/teamManager.js
@@ -53,14 +53,17 @@ function renderAvailableUnitsList() {
 
     availableUnits.forEach(unit => {
         const unitItem = document.createElement('div');
-        unitItem.className = 'unit-item-draggable';
+        unitItem.className = 'list-item list-item-grid draggable';
         unitItem.draggable = true;
         unitItem.dataset.unitId = unit.id; // Store full ID for getUnitById
         unitItem.innerHTML = `
-            <img src="${unit.imagePath}" alt="${unit.name} ${unit.version}" onerror="this.style.display='none'; this.parentElement.querySelector('strong').textContent += ' (Img Fail)';">
-            <div class="unit-item-info">
-                <strong>${unit.name} (${unit.version})</strong>
-                <span>H:${unit.health} M:${unit.move} R:${unit.range} Hit:${unit.chance_to_hit}%</span>
+            <div class="list-item-icon">
+                <img src="${unit.imagePath}" alt="${unit.name} ${unit.version}" onerror="this.style.display='none';">
+            </div>
+            <div class="list-item-content">
+                <div class="list-item-title">${unit.name}</div>
+                <div class="list-item-subtitle">${unit.version}</div>
+                <div class="list-item-description">H:${unit.health} M:${unit.move}</div>
             </div>
         `;
         unitItem.addEventListener('dragstart', (event) => {


### PR DESCRIPTION
## Summary
- rewrite team tab markup and populate available units with standardized list items
- refresh loadout tab markup and weapon listings
- tweak styles for new list item layouts
- document redesign in `devlog.md`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848b3bc2768833287241fef82559f02