### PR TITLE
Update grid labels visibility logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
 - 1507 Break up worldGeneration.js into modular files
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
+- 1623 Label every grid cell and keep labels visible only when the grid is toggled
 
 ## 2025-06-28
 - 0100 Rig up running animation on Shift key press for animated player model.
@@ -16,9 +17,6 @@
 
 ## 2025-06-26
 - 2314 Add theme stylesheet and replace color constants
-- 2309 Update remote players to run custom animations each frame
-- 2257 Add animated player replace button and improved options styling
-- 2242 Add options menu with asset downloader and glb analysis scripts
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -26,3 +26,6 @@
 - 2221 Document new agents directory and split instructions
 - 2218 Fade chat bubbles before hiding
 - 2214 Show sent chat immediately and keep log of messages
+- 2309 Update remote players to run custom animations each frame
+- 2257 Add animated player replace button and improved options styling
+- 2242 Add options menu with asset downloader and glb analysis scripts

--- a/js/worldgen/groundGrid.js
+++ b/js/worldgen/groundGrid.js
@@ -78,8 +78,12 @@ export function createGroundGrid(terrain, size, divisions, colorCenterLine, colo
 
     const labelsGroup = new THREE.Group();
     labelsGroup.name = 'grid-labels-group'; // Add name for easy lookup
-    /* @tweakable The number of grid cells to skip between rendering labels. Higher values improve performance. */
-    const labelSkip = 8;
+    /*
+     * @tweakable The number of grid cells to skip between rendering labels.
+     * A value of `1` labels every cell. Higher values improve performance by
+     * reducing the number of generated labels.
+     */
+    const labelSkip = 1;
 
     for (let i = 0; i < divisions; i += labelSkip) {
         for (let j = 0; j < divisions; j += labelSkip) {


### PR DESCRIPTION
## Summary
- label every grid cell in `createGroundGrid`
- keep labels hidden until grid is toggled and only show near player
- update changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68752e5539588332b0902613d0a3fc41