### PR TITLE
Lazy grid label creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement
+- 1706 Generate grid labels on demand to eliminate DOM lag
 
 ## 2025-06-28
 - 0100 Rig up running animation on Shift key press for animated player model.
 
 ## 2025-06-27
-- 1623 Fix stylesheet path in index.html
 - 1633 Add circle-button class and apply to UI buttons
 - 1742 Fix idle animation orientation for animated player model
 - 1815 Hide mobile/desktop toggle and rely on auto-detection

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -30,3 +30,6 @@
 - 2309 Update remote players to run custom animations each frame
 - 2257 Add animated player replace button and improved options styling
 - 2242 Add options menu with asset downloader and glb analysis scripts
+
+## 2025-06-27
+- 1623 Fix stylesheet path in index.html

--- a/js/app.js
+++ b/js/app.js
@@ -282,6 +282,11 @@ async function main() {
       if (labelsGroup) {
         labelsGroup.visible = gridHelper.visible;
       }
+      if (!gridHelper.visible) {
+        gridHelper.userData.clearLabels();
+      } else {
+        gridHelper.userData.updateLabels(playerModel.position, GRID_LABEL_VISIBILITY_DISTANCE, GRID_LABEL_LOD_DISTANCE, GRID_LABEL_LOD_STEP);
+      }
     }
   });
 
@@ -302,26 +307,13 @@ async function main() {
     labelUpdateCounter++;
     if (labelUpdateCounter >= labelUpdateInterval) {
         labelUpdateCounter = 0;
-        // Dynamically update grid label visibility to improve performance
-        const labelsGroup = gridHelper.getObjectByName('grid-labels-group');
-        if (labelsGroup) {
-            if (gridHelper.visible) {
-                const playerPosition = playerModel.position;
-                labelsGroup.children.forEach((label) => {
-                    const distance = label.position.distanceTo(playerPosition);
-                    
-                    if (distance < GRID_LABEL_VISIBILITY_DISTANCE) {
-                        label.visible = true;
-                    } else if (distance < GRID_LABEL_LOD_DISTANCE) {
-                        const { i, j } = label.userData.gridIndices || { i: -1, j: -1 };
-                        label.visible = (i % GRID_LABEL_LOD_STEP === 0) && (j % GRID_LABEL_LOD_STEP === 0);
-                    } else {
-                        label.visible = false;
-                    }
-                });
-            } else {
-                labelsGroup.children.forEach(label => label.visible = false);
-            }
+        if (gridHelper.visible) {
+            gridHelper.userData.updateLabels(
+                playerModel.position,
+                GRID_LABEL_VISIBILITY_DISTANCE,
+                GRID_LABEL_LOD_DISTANCE,
+                GRID_LABEL_LOD_STEP
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- generate grid labels on demand instead of up front
- hook lazy label logic into main update loop
- document the optimization in the changelog
- archive the oldest changelog entry

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687537a8d84c83328f7cf9244229e8d8