### PR TITLE
Fix player model replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-07-14
+- 1818 Fix player asset replacement to avoid duplicate player model
 - 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
 - 1507 Break up worldGeneration.js into modular files
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
@@ -12,11 +13,6 @@
 
 ## 2025-06-28
 - 0100 Rig up running animation on Shift key press for animated player model.
-
-## 2025-06-27
-- 1633 Add circle-button class and apply to UI buttons
-- 1742 Fix idle animation orientation for animated player model
-- 1815 Hide mobile/desktop toggle and rely on auto-detection
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -33,3 +33,5 @@
 
 ## 2025-06-27
 - 1623 Fix stylesheet path in index.html
+- 1742 Fix idle animation orientation for animated player model
+- 1815 Hide mobile/desktop toggle and rely on auto-detection

--- a/js/app.js
+++ b/js/app.js
@@ -168,6 +168,7 @@ async function main() {
   const assetReplacementManager = new AssetReplacementManager({
     playerControls,
     npcManager,
+    onPlayerModelReplaced: (model) => { playerModel = model; }
   });
 
   const characterCreator = new CharacterCreator(

--- a/js/assetReplacementManager.js
+++ b/js/assetReplacementManager.js
@@ -8,6 +8,8 @@ export class AssetReplacementManager {
         this.downloader = new Downloader();
         this.assets = null;
         this.statusElement = null;
+        // Optional callback for when the player model is replaced
+        this.onPlayerModelReplaced = dependencies.onPlayerModelReplaced || null;
 
         this.modelTypes = {
             'player': {
@@ -189,6 +191,9 @@ export class AssetReplacementManager {
             controls.playerModel = model;
             controls.playerModel.userData.isGLB = true;
             controls.currentAction = 'idle';
+            if (this.onPlayerModelReplaced) {
+                this.onPlayerModelReplaced(model);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- hook up callback for player asset replacements
- update global reference when player asset changes
- prune older changelog entries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875497a576883329282e56aed1952a0