### PR TITLE
Implement climbable seat row collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,17 @@
 
 ## 2025-07-15
 - 1200 Fix shopkeeper not spawning and improve interaction system performance
+- 1851 Add climbable seat rows by treating them as stairs for collision
 
 ## 2025-07-14
 - 1818 Fix player asset replacement to avoid duplicate player model
 - 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
-- 1507 Break up worldGeneration.js into modular files
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement
 - 1706 Generate grid labels on demand to eliminate DOM lag
 - 1747 Ensure joystick containers display on mobile initialization
 - 1758 Correct A/D key mapping and improve mobile joystick handling
-
-## 2025-06-28
-- 0100 Rig up running animation on Shift key press for animated player model.
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -35,3 +35,7 @@
 - 1623 Fix stylesheet path in index.html
 - 1742 Fix idle animation orientation for animated player model
 - 1815 Hide mobile/desktop toggle and rely on auto-detection
+
+## 2025-06-28
+- 0100 Rig up running animation on Shift key press for animated player model.
+- 1507 Break up worldGeneration.js into modular files

--- a/js/collisionManager.js
+++ b/js/collisionManager.js
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 
 /* @tweakable The radius around the player to check for collisions. Lower values can improve performance but may cause missed collisions with distant objects. */
 const COLLISION_CHECK_RADIUS = 10;
+/* @tweakable Maximum height the player can step onto without jumping. */
+const STEP_HEIGHT = 1.0;
 /* @tweakable Additional padding around NPCs for collision detection. */
 const NPC_COLLISION_PADDING = 0.2;
 
@@ -102,7 +104,18 @@ export class CollisionManager {
         ) {
             standingOnBlock = true;
             newY = blockTop; // Player's feet height
-        } 
+        } else if (
+            block.userData.isStair &&
+            velocity.y <= 0 &&
+            currentPosition.y >= blockTop - STEP_HEIGHT &&
+            newPosition.y <= blockTop + 0.2 &&
+            Math.abs(newPosition.x - blockCenter.x) < (blockWidth / 2 + effectivePlayerRadius) &&
+            Math.abs(newPosition.z - blockCenter.z) < (blockDepth / 2 + effectivePlayerRadius)
+        ) {
+            // Allow stepping onto stairs and seat rows without jumping
+            standingOnBlock = true;
+            newY = blockTop;
+        }
         // Check for side collision
         else if (
             Math.abs(newPosition.x - blockCenter.x) < (blockWidth / 2 + effectivePlayerRadius) &&

--- a/js/worldgen/amphitheatre.js
+++ b/js/worldgen/amphitheatre.js
@@ -96,6 +96,7 @@ function createStage(dimensions) {
         stair.castShadow = true;
         stair.receiveShadow = true;
         stair.userData.isBlock = true;
+        stair.userData.isStair = true;
     
         stairsGroup.add(stair);
     }
@@ -135,6 +136,7 @@ function createSeatRow(rowIndex, radius, seatCount, rowHeight) {
         baseMesh.castShadow = true;
         baseMesh.receiveShadow = true;
         baseMesh.userData.isBlock = true;
+        baseMesh.userData.isStair = true;
 
         rowGroup.add(baseMesh);
     }


### PR DESCRIPTION
## Summary
- make stage steps collidable as stairs
- add stair userData for amphitheatre seat rows
- allow stepping onto stair objects in collision manager
- document change in changelog
- archive older changelog entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876a21df5508332b3cd9837c7a07f76