### PR TITLE
Fix collidable seat rows in amphitheatre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 - 1200 Fix shopkeeper not spawning and improve interaction system performance
 - 1848 Add package.json with Node.js 18 requirement
 - 1851 Add climbable seat rows by treating them as stairs for collision
+- 1917 Make seat rows collidable by marking each row group as a block
 
 ## 2025-07-14
-- 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -32,6 +32,7 @@
 
 ## 2025-07-14
 - 1818 Fix player asset replacement to avoid duplicate player model.
+- 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
 
 ## 2025-06-28
 - 0100 Rig up running animation on Shift key press for animated player model.

--- a/js/worldgen/amphitheatre.js
+++ b/js/worldgen/amphitheatre.js
@@ -105,6 +105,9 @@ function createStage(dimensions) {
 
 function createSeatRow(rowIndex, radius, seatCount, rowHeight) {
     const rowGroup = new THREE.Group();
+    // Mark the entire row as collidable so players can't walk through the seats
+    rowGroup.userData.isBlock = true;
+    rowGroup.userData.isStair = true;
     const seatMaterial = new THREE.MeshStandardMaterial({ color: stoneColor, roughness: 0.9, metalness: 0.05 });
 
     for (let i = 0; i < seatCount; i++) {


### PR DESCRIPTION
## Summary
- mark amphitheatre seat rows as blocks
- archive the oldest changelog entry
- document the collision fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a83de4b48332b47ef3f135ff4cef