### PR TITLE
Fix seat geometry bounding data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,20 @@
 # Changelog
 
+## 2025-07-17
+- 2005 Compute amphitheater seat geometry bounds before adding to scene
+
 ## 2025-07-15
 - 1210 Fix amphitheater seat collision by correctly positioning the seats and improving collision padding logic.
 - 1205 Fix compass not displaying directions and add tweakable offset
 - 1200 Fix shopkeeper not spawning and improve interaction system performance
 
 ## 2025-07-14
-- 1818 Fix player asset replacement to avoid duplicate player model
-- 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
-- 1507 Break up worldGeneration.js into modular files
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement
 - 1706 Generate grid labels on demand to eliminate DOM lag
 - 1747 Ensure joystick containers display on mobile initialization
 - 1758 Correct A/D key mapping and improve mobile joystick handling
-
-## 2025-06-28
-- 0100 Rig up running animation on Shift key press for animated player model.
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -35,3 +35,11 @@
 - 1623 Fix stylesheet path in index.html
 - 1742 Fix idle animation orientation for animated player model
 - 1815 Hide mobile/desktop toggle and rely on auto-detection
+
+## 2025-06-28
+- 0100 Rig up running animation on Shift key press for animated player model.
+
+## 2025-07-14
+- 1818 Fix player asset replacement to avoid duplicate player model
+- 1522 Fix HouseBlocks module loading error by merging it into starterHouse.js
+- 1507 Break up worldGeneration.js into modular files

--- a/js/worldgen/amphi-seats.js
+++ b/js/worldgen/amphi-seats.js
@@ -33,6 +33,8 @@ export function createSeatRow(rowIndex, radius, seatCount, rowHeight) {
             bevelEnabled: false,
         };
         const geometry = new THREE.ExtrudeGeometry(baseShape, extrudeSettings);
+        geometry.computeBoundingSphere();
+        geometry.computeBoundingBox();
         const baseMesh = new THREE.Mesh(geometry, seatMaterial);
         baseMesh.rotation.x = -Math.PI / 2;
         baseMesh.position.y = y;


### PR DESCRIPTION
## Summary
- compute bounding volumes for the amphitheater seat geometry
- keep only the 10 most recent changelog entries
- archive older entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879571de22c8332838bcf1791277d56