### PR TITLE
Rotate amphitheater seats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 2147 Convert lyrics display to canvas texture so it hides behind objects
 - 2158 Update lyrics with corrected lines
+- 2208 Rotate amphitheater seats 90 degrees counter-clockwise and update collision angles
 
 
 ## 2025-07-17
@@ -17,7 +18,6 @@
 - 1200 Fix shopkeeper not spawning and improve interaction system performance
 
 ## 2025-07-14
-- 1706 Generate grid labels on demand to eliminate DOM lag
 - 1747 Ensure joystick containers display on mobile initialization
 - 1758 Correct A/D key mapping and improve mobile joystick handling
 

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -49,3 +49,4 @@
 - 1555 Restrict grid labels to show within 7m radius when grid toggled
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement
+- 1706 Generate grid labels on demand to eliminate DOM lag

--- a/js/worldgen/amphi-seats.js
+++ b/js/worldgen/amphi-seats.js
@@ -5,7 +5,7 @@ import * as THREE from 'three';
  * @param {THREE.Group} group The group to add seating to.
  * @param {THREE.Color | number} stoneColor The color of the seats.
  */
-export function createAmphitheatreSeating(group, stoneColor) {
+export function createAmphitheatreSeating(group, stoneColor, rotationY = 0) {
     /* @tweakable The number of seating rows. */
     const numRows = 8;
     /* @tweakable The height of each seating row. */
@@ -49,13 +49,15 @@ export function createAmphitheatreSeating(group, stoneColor) {
         geometry.rotateX(-Math.PI / 2);
         
         const seatRow = new THREE.Mesh(geometry, material);
+        seatRow.rotation.y = rotationY;
         seatRow.castShadow = true;
         seatRow.receiveShadow = true;
         seatRow.userData.isSeatRow = true;
         
         // Normalize angles to be in the [0, 2*PI] range for consistent collision checks.
-        const normalizedStartAngle = startAngle < 0 ? startAngle + 2 * Math.PI : startAngle;
-        const normalizedEndAngle = endAngle < 0 ? endAngle + 2 * Math.PI : endAngle;
+        const normalize = (a) => (a % (2 * Math.PI) + 2 * Math.PI) % (2 * Math.PI);
+        const normalizedStartAngle = normalize(startAngle + rotationY);
+        const normalizedEndAngle = normalize(endAngle + rotationY);
 
         seatRow.userData.seatRowData = {
             innerRadius,

--- a/js/worldgen/amphitheatre.js
+++ b/js/worldgen/amphitheatre.js
@@ -292,7 +292,8 @@ export function createAmphitheatre(scene, getHeight) {
     group.add(spotLight2);
 
     if (enableSeating) {
-        createAmphitheatreSeating(group, stoneColor);
+        const seatRotationY = Math.PI / 2; // Rotate seats 90 degrees counter-clockwise
+        createAmphitheatreSeating(group, stoneColor, seatRotationY);
     }
 
     return group;


### PR DESCRIPTION
## Summary
- rotate amphitheater seats by 90° counter-clockwise
- keep collision angles aligned with new rotation
- record change in changelog and archive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb9868ad883329e4c0965f5f740e8