### PR TITLE
Improve NPC collision accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - 2147 Convert lyrics display to canvas texture so it hides behind objects
 - 2158 Update lyrics with corrected lines
 - 2208 Rotate amphitheater seats 90 degrees counter-clockwise and update collision angles
+- 2217 Use per-model bounding boxes for NPC collision detection
 
 
 ## 2025-07-17
@@ -16,10 +17,6 @@
 - 1210 Fix amphitheater seat collision by correctly positioning the seats and improving collision padding logic.
 - 1205 Fix compass not displaying directions and add tweakable offset
 - 1200 Fix shopkeeper not spawning and improve interaction system performance
-
-## 2025-07-14
-- 1747 Ensure joystick containers display on mobile initialization
-- 1758 Correct A/D key mapping and improve mobile joystick handling
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -50,3 +50,5 @@
 - 1623 Label every grid cell and keep labels visible only when the grid is toggled
 - 1640 Enable dual joysticks for mobile look and movement
 - 1706 Generate grid labels on demand to eliminate DOM lag
+- 1747 Ensure joystick containers display on mobile initialization
+- 1758 Correct A/D key mapping and improve mobile joystick handling

--- a/js/npc/NPCSpawner.js
+++ b/js/npc/NPCSpawner.js
@@ -285,7 +285,17 @@ export class NPCSpawner {
 
             newModel.position.copy(npc.model.position);
             npc.model = newModel;
-            
+
+            // Update NPC collision bounds
+            npc.boundingBox = new THREE.Box3().setFromObject(newModel);
+            const size = new THREE.Vector3();
+            npc.boundingBox.getSize(size);
+            npc.collisionRadius = Math.max(size.x, size.z) / 2;
+            npc.collisionHeight = size.y;
+            if (npc.isEyebot) {
+                npc.eyebotCollisionRadius = npc.collisionRadius;
+            }
+
             this.scene.add(newModel);
         });
     }


### PR DESCRIPTION
## Summary
- update NPCs to compute bounding box-based collision shapes
- use per-model radius and height when calling collision routines
- ensure replaced NPCs recompute their bounds
- document the change in the changelog
- archive older changelog entries

## Testing
- `npm test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ebbd7ea1083329595eed817d1daa2