### PR TITLE
Update changelog retention rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,6 @@ Read them all before contributing:
 Key points:
 
 - Update `CHANGELOG.md` for every change using UTC dates and an `HHMM` prefix for each bullet.
-- Keep only the most recent ten entries in `CHANGELOG.md`. Move older ones to `CHANGELOG_ARCHIVE.md`.
+- Keep only the most recent ten entries from previous days in `CHANGELOG.md`. Move older ones to `CHANGELOG_ARCHIVE.md`. Entries from the current UTC day may exceed this count.
 - Run `npm test` or any project-specific tests before committing. Document test issues caused by environment limits in the pull request.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 2158 Update lyrics with corrected lines
 - 2208 Rotate amphitheater seats 90 degrees counter-clockwise and update collision angles
 - 2217 Use per-model bounding boxes for NPC collision detection
+- 2223 Clarify changelog entry retention rules to allow unlimited current-day items
 
 
 ## 2025-07-17

--- a/agents/changelog.md
+++ b/agents/changelog.md
@@ -4,4 +4,4 @@ Changelog Updates
 - Record each change in `CHANGELOG.md` with a short bullet summary.
 - Group bullets under a heading using `date -u +%Y-%m-%d` for the date.
 - Prefix every bullet with the time from `date -u +%H%M`.
-- Keep only the latest ten bullet entries in `CHANGELOG.md` and move older ones to `CHANGELOG_ARCHIVE.md`.
+- Keep only the latest ten bullet entries from days before today in `CHANGELOG.md` and move older ones to `CHANGELOG_ARCHIVE.md`. Bullets from the current UTC day may exceed this limit.


### PR DESCRIPTION
## Summary
- clarify rules for changelog bullet retention in AGENTS guidelines
- allow current-day bullet list to exceed ten items
- document rule change in CHANGELOG

## Testing
- `npm test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ebd78bfb88332884c358d5cecd397