### PR TITLE
Refactor OptionsUI into modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-07-22
+
+- 1751 Refactor OptionsUI into smaller modules
+
 ## 2025-07-21
 
 - 2146 Update contribution guidelines in AGENTS files

--- a/ui/options/adminTab.js
+++ b/ui/options/adminTab.js
@@ -1,0 +1,44 @@
+export async function addAdminTab(dependencies) {
+    const currentUser = await window.websim.getCurrentUser();
+    const adminUsername = 'lordtsarcasm';
+
+    if (currentUser && currentUser.username === adminUsername) {
+        const tabsContainer = document.querySelector('#options-tabs');
+        const contentContainer = document.querySelector('#options-content');
+
+        const adminTab = document.createElement('button');
+        adminTab.className = 'options-tab admin-tab';
+        adminTab.dataset.tab = 'admin';
+        adminTab.textContent = 'Admin';
+        tabsContainer.appendChild(adminTab);
+
+        const adminContent = document.createElement('div');
+        adminContent.id = 'options-tab-admin';
+        adminContent.className = 'options-tab-content';
+        adminContent.innerHTML = `
+            <h3>Admin Controls</h3>
+            <div class="option-item">
+                <label for="youtube-url-input">Video URL:</label>
+                <input type="text" id="youtube-url-input" placeholder="Enter video file URL...">
+            </div>
+            <button id="save-youtube-url" class="option-button" data-tooltip="Update the video screen for everyone">Set Video</button>
+        `;
+        contentContainer.appendChild(adminContent);
+
+        adminContent.querySelector('#save-youtube-url').addEventListener('click', () => {
+            const url = adminContent.querySelector('#youtube-url-input').value;
+            if (dependencies.room) {
+                dependencies.room.updateRoomState({ youtubeUrl: url });
+            }
+        });
+
+        adminTab.addEventListener('click', (e) => {
+            document.querySelectorAll('.options-tab').forEach(t => t.classList.remove('active'));
+            e.target.classList.add('active');
+            document.querySelectorAll('.options-tab-content').forEach(content => {
+                content.classList.remove('active');
+            });
+            adminContent.classList.add('active');
+        });
+    }
+}

--- a/ui/options/assetControls.js
+++ b/ui/options/assetControls.js
@@ -1,0 +1,49 @@
+export function setupAssetControls(modal, assetReplacementManager) {
+    const toggleReplaceButtons = (show) => {
+        const container = modal.querySelector('#asset-replacement-buttons');
+        if (container) {
+            container.style.display = show ? 'grid' : 'none';
+        }
+    };
+
+    toggleReplaceButtons(false);
+
+    modal.querySelector('#download-assets').addEventListener('click', async () => {
+        const success = await assetReplacementManager.downloadExternalAssets();
+        if (success) {
+            toggleReplaceButtons(true);
+        }
+    });
+
+    modal.querySelector('#use-all-assets-button').addEventListener('click', () => {
+        assetReplacementManager.replaceAllModels();
+    });
+
+    modal.querySelector('#replace-player-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('player');
+    });
+    modal.querySelector('#replace-robots-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('robot');
+    });
+    modal.querySelector('#replace-eyebots-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('eyebot');
+    });
+    modal.querySelector('#replace-chickens-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('chicken');
+    });
+    modal.querySelector('#replace-wireframes-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('wireframe');
+    });
+    modal.querySelector('#replace-aliens-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('alien');
+    });
+    modal.querySelector('#replace-shopkeeper-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('shopkeeper');
+    });
+    modal.querySelector('#replace-ogres-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('ogre');
+    });
+    modal.querySelector('#replace-knights-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('knight');
+    });
+}

--- a/ui/options/performance.js
+++ b/ui/options/performance.js
@@ -1,0 +1,82 @@
+import * as THREE from 'three';
+
+export function applyPerformanceMode(ui, enabled) {
+    const shadowSelect = document.getElementById('shadow-quality');
+    const viewDistanceSlider = document.getElementById('view-distance');
+    const viewDistanceValue = document.getElementById('view-distance-value');
+
+    if (enabled) {
+        if (!ui.prePerformanceSettings) {
+            ui.prePerformanceSettings = {
+                shadowQuality: shadowSelect.value,
+                viewDistance: viewDistanceSlider.value
+            };
+        }
+        applyShadowQuality(ui, 'off');
+        shadowSelect.value = 'off';
+        shadowSelect.disabled = true;
+
+        const performanceViewDistance = 75;
+        ui.playerControls.camera.far = performanceViewDistance;
+        ui.playerControls.camera.updateProjectionMatrix();
+        viewDistanceSlider.value = performanceViewDistance;
+        viewDistanceSlider.disabled = true;
+        viewDistanceValue.textContent = performanceViewDistance;
+
+    } else {
+        if (ui.prePerformanceSettings) {
+            applyShadowQuality(ui, ui.prePerformanceSettings.shadowQuality);
+            shadowSelect.value = ui.prePerformanceSettings.shadowQuality;
+
+            const restoredViewDistance = parseInt(ui.prePerformanceSettings.viewDistance);
+            ui.playerControls.camera.far = restoredViewDistance;
+            ui.playerControls.camera.updateProjectionMatrix();
+            viewDistanceSlider.value = restoredViewDistance;
+            viewDistanceValue.textContent = restoredViewDistance;
+
+            ui.prePerformanceSettings = null;
+        }
+        shadowSelect.disabled = false;
+        viewDistanceSlider.disabled = false;
+    }
+}
+
+export function applyShadowQuality(ui, quality) {
+    if (!ui.renderer || !ui.dirLight) return;
+
+    switch (quality) {
+        case 'high':
+            ui.renderer.shadowMap.enabled = true;
+            ui.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+            ui.dirLight.castShadow = true;
+            ui.dirLight.shadow.mapSize.width = 2048;
+            ui.dirLight.shadow.mapSize.height = 2048;
+            ui.dirLight.shadow.radius = 2.0;
+            break;
+        case 'medium':
+            ui.renderer.shadowMap.enabled = true;
+            ui.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+            ui.dirLight.castShadow = true;
+            ui.dirLight.shadow.mapSize.width = 1024;
+            ui.dirLight.shadow.mapSize.height = 1024;
+            ui.dirLight.shadow.radius = 1.5;
+            break;
+        case 'low':
+            ui.renderer.shadowMap.enabled = true;
+            ui.renderer.shadowMap.type = THREE.PCFShadowMap;
+            ui.dirLight.castShadow = true;
+            ui.dirLight.shadow.mapSize.width = 512;
+            ui.dirLight.shadow.mapSize.height = 512;
+            break;
+        case 'off':
+            ui.renderer.shadowMap.enabled = false;
+            ui.dirLight.castShadow = false;
+            break;
+    }
+
+    ui.scene.traverse(obj => {
+        if (obj.material) {
+            obj.material.needsUpdate = true;
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- break OptionsUI.js into adminTab, assetControls, and performance modules
- update imports and calls to use new modules
- document refactor in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fce91e7f88332a282ae0e5a0ab1fe