### PR TITLE
Add music modal with song list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-07-22
+
+- 2122 Add music button and modal with scrollable song and collaborator lists
+
 ## 2025-07-21
 
 - 2146 Update contribution guidelines in AGENTS files

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
   <link rel="stylesheet" href="styles/responsive.css">
   <link rel="stylesheet" href="styles/map.css">
   <link rel="stylesheet" href="styles/changelog.css">
+  <link rel="stylesheet" href="styles/music.css">
   <link rel="stylesheet" href="styles/options.css">
   <link rel="stylesheet" href="styles/interaction.css">
   <link rel="stylesheet" href="styles/compass.css">

--- a/js/uiManager.js
+++ b/js/uiManager.js
@@ -8,6 +8,7 @@ import { InventoryUI } from '../ui/inventoryUI.js';
 import { MapUI } from '../ui/mapUI.js';
 import { OptionsUI } from '../ui/optionsUI.js';
 import { CompassUI } from '../ui/compassUI.js';
+import { MusicUI } from '../ui/musicUI.js';
 
 export class UIManager {
     constructor(dependencies) {
@@ -40,6 +41,8 @@ export class UIManager {
 
         this.mapUI = new MapUI(this.dependencies);
         this.mapUI.create();
+
+        new MusicUI(this.dependencies).create();
 
         this.compassUI = new CompassUI(this.dependencies);
         this.compassUI.create();

--- a/styles/music.css
+++ b/styles/music.css
@@ -1,0 +1,96 @@
+#music-button {
+    position: fixed;
+    bottom: 360px;
+    right: 20px;
+    z-index: 1000;
+    touch-action: none;
+    cursor: pointer;
+}
+
+/* Mobile layout */
+.mobile-device #music-button {
+    bottom: 430px;
+    right: 20px;
+}
+
+#music-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: var(--black-90);
+    color: white;
+    padding: 20px;
+    border-radius: 10px;
+    /* wa-hey */
+    width: 69%;
+    max-width: 600px;
+    max-height: 80%;
+    display: none;
+    box-shadow: 0 0 20px var(--black-50);
+    pointer-events: auto;
+    overflow: hidden;
+    z-index: 2100;
+}
+
+#music-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#close-music {
+    width: 20px;
+    height: 20px;
+    background-color: var(--white-70);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 20px;
+    font-weight: bold;
+    color: #333;
+    cursor: pointer;
+}
+
+#music-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--white-20);
+}
+
+.music-tab {
+    flex: 1;
+    padding: 10px;
+    background: transparent;
+    border: none;
+    color: var(--white-70);
+    cursor: pointer;
+    font-size: 16px;
+    border-bottom: 2px solid transparent;
+}
+
+.music-tab.active {
+    color: var(--white-full);
+    border-bottom: 2px solid #2196F3;
+    font-weight: bold;
+}
+
+#music-content {
+    padding: 15px 0;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.music-tab-content {
+    display: none;
+}
+
+.music-tab-content.active {
+    display: block;
+}
+
+#music-song-list,
+#music-collaborators-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -39,6 +39,12 @@
     /* @tweakable The right position of the map button on mobile. */
     right: 20px;
 }
+.mobile-device #music-button {
+    /* @tweakable The bottom position of the music button on mobile. */
+    bottom: 430px;
+    /* @tweakable The right position of the music button on mobile. */
+    right: 20px;
+}
 .mobile-device #inventory-button {
     /* @tweakable The bottom position of the inventory button on mobile. */
     bottom: 220px;

--- a/ui/musicUI.js
+++ b/ui/musicUI.js
@@ -1,0 +1,71 @@
+export class MusicUI {
+    constructor(dependencies) {
+        this.playerControls = dependencies.playerControls;
+    }
+
+    create() {
+        const uiContainer = document.getElementById('ui-container');
+
+        const button = document.createElement('div');
+        button.id = 'music-button';
+        button.classList.add('circle-button');
+        button.setAttribute('data-tooltip', 'Music');
+        button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M9 3v12a4 4 0 11-2-3.465V6h8V3H9z"/></svg>`;
+        uiContainer.appendChild(button);
+
+        const modal = document.createElement('div');
+        modal.id = 'music-modal';
+        modal.style.display = 'none';
+        modal.innerHTML = `
+            <div id="music-header">
+                <h2>Music</h2>
+                <div id="close-music" data-tooltip="Close">✕</div>
+            </div>
+            <div id="music-tabs">
+                <button class="music-tab active" data-tab="songs">Songs</button>
+                <button class="music-tab" data-tab="collaborators">Collaborators</button>
+            </div>
+            <div id="music-content">
+                <div id="music-tab-songs" class="music-tab-content active">
+                    <ul id="music-song-list">
+                        <li>Placeholder Song 1</li>
+                        <li>Placeholder Song 2</li>
+                        <li>Placeholder Song 3</li>
+                        <li>Placeholder Song 4</li>
+                        <li>Placeholder Song 5</li>
+                    </ul>
+                </div>
+                <div id="music-tab-collaborators" class="music-tab-content">
+                    <ul id="music-collaborators-list">
+                        <li>Alice</li>
+                        <li>Bob</li>
+                        <li>Carol</li>
+                        <li>Dave</li>
+                        <li>Eve</li>
+                    </ul>
+                </div>
+            </div>
+        `;
+        uiContainer.appendChild(modal);
+
+        button.addEventListener('click', () => {
+            modal.style.display = 'block';
+            if (this.playerControls) this.playerControls.enabled = false;
+        });
+
+        modal.querySelector('#close-music').addEventListener('click', () => {
+            modal.style.display = 'none';
+            if (this.playerControls) this.playerControls.enabled = true;
+        });
+
+        modal.querySelectorAll('.music-tab').forEach(tab => {
+            tab.addEventListener('click', (e) => {
+                const tabName = e.target.dataset.tab;
+                modal.querySelectorAll('.music-tab').forEach(t => t.classList.remove('active'));
+                e.target.classList.add('active');
+                modal.querySelectorAll('.music-tab-content').forEach(content => content.classList.remove('active'));
+                modal.querySelector(`#music-tab-${tabName}`).classList.add('active');
+            });
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a MusicUI that opens a modal with song and collaborator tabs
- style the music modal and button
- integrate MusicUI in UIManager
- link `music.css`
- adjust responsive layout for music button
- document the new feature

## Testing
- `npm test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6880002b316883329060f3d41ff2239c