### PR TITLE
Rewrite mats.json to use modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-07-23
+- 0000 Rewrite mats.json to load modules from js/mats
+
 ## 2025-07-22
 
 - 2123 Add distinct biomes and tree types. The world now features five biomes: a central Grassland, Sand (Palm trees), Snow (Snowy Pine trees), Forest (Deciduous and Pine trees), and Dirt/Stone (Sparse, bare trees).
@@ -22,7 +25,6 @@
 ## 2025-07-15
 - 1210 Fix amphitheater seat collision by correctly positioning the seats and improving collision padding logic.
 - 1205 Fix compass not displaying directions and add tweakable offset
-- 1200 Fix shopkeeper not spawning and improve interaction system performance
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -1,5 +1,8 @@
 # Changelog Archive
 
+## 2025-07-15
+- 1200 Fix shopkeeper not spawning and improve interaction system performance
+
 ## 2025-06-26
 - **7d0177a** Merge: extend MapUI to handle scene objects
 - **d335b69** Use texture sampling for map terrain

--- a/js/mats/createMaterial.js
+++ b/js/mats/createMaterial.js
@@ -1,0 +1,18 @@
+import * as THREE from 'three';
+
+export function createMaterial(textureDir, repeatU = 1, repeatV = 1) {
+  const loader = new THREE.TextureLoader();
+  const textures = {
+    map: loader.load(`${textureDir}albedo.png`),
+    normalMap: loader.load(`${textureDir}normal.png`),
+    roughnessMap: loader.load(`${textureDir}roughness.png`),
+    aoMap: loader.load(`${textureDir}ao.png`),
+  };
+  for (const tex of Object.values(textures)) {
+    if (tex) {
+      tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+      tex.repeat.set(repeatU, repeatV);
+    }
+  }
+  return new THREE.MeshStandardMaterial(textures);
+}

--- a/js/mats/int_carpet.js
+++ b/js/mats/int_carpet.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/interior/carpet/', repeatU, repeatV);
+}

--- a/js/mats/int_ceramicTile.js
+++ b/js/mats/int_ceramicTile.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/interior/ceramicTile/', repeatU, repeatV);
+}

--- a/js/mats/int_hardwood.js
+++ b/js/mats/int_hardwood.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/interior/hardwood/', repeatU, repeatV);
+}

--- a/js/mats/int_plaster.js
+++ b/js/mats/int_plaster.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/interior/plaster/', repeatU, repeatV);
+}

--- a/js/mats/roof_asphalt.js
+++ b/js/mats/roof_asphalt.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/roofing/asphaltShingles/', repeatU, repeatV);
+}

--- a/js/mats/roof_clay.js
+++ b/js/mats/roof_clay.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/roofing/clayTiles/', repeatU, repeatV);
+}

--- a/js/mats/roof_metal.js
+++ b/js/mats/roof_metal.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/roofing/metalPanels/', repeatU, repeatV);
+}

--- a/js/mats/roof_slate.js
+++ b/js/mats/roof_slate.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/roofing/slate/', repeatU, repeatV);
+}

--- a/js/mats/siding_brickVeneer.js
+++ b/js/mats/siding_brickVeneer.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/siding/brickVeneer/', repeatU, repeatV);
+}

--- a/js/mats/siding_fiberCement.js
+++ b/js/mats/siding_fiberCement.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/siding/fiberCement/', repeatU, repeatV);
+}

--- a/js/mats/siding_stucco.js
+++ b/js/mats/siding_stucco.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/siding/stucco/', repeatU, repeatV);
+}

--- a/js/mats/siding_vinyl.js
+++ b/js/mats/siding_vinyl.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/siding/vinylSiding/', repeatU, repeatV);
+}

--- a/js/mats/siding_wood.js
+++ b/js/mats/siding_wood.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/claddingAndSiding/woodSiding/', repeatU, repeatV);
+}

--- a/js/mats/struct_brick.js
+++ b/js/mats/struct_brick.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/brick/', repeatU, repeatV);
+}

--- a/js/mats/struct_cementboard.js
+++ b/js/mats/struct_cementboard.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/cementBoard/', repeatU, repeatV);
+}

--- a/js/mats/struct_concrete.js
+++ b/js/mats/struct_concrete.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/concrete/', repeatU, repeatV);
+}

--- a/js/mats/struct_steel.js
+++ b/js/mats/struct_steel.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/steel/', repeatU, repeatV);
+}

--- a/js/mats/struct_stone.js
+++ b/js/mats/struct_stone.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/stone/', repeatU, repeatV);
+}

--- a/js/mats/struct_wood.js
+++ b/js/mats/struct_wood.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/structural/wood/', repeatU, repeatV);
+}

--- a/js/mats/wall_drywall.js
+++ b/js/mats/wall_drywall.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/walls/drywall/', repeatU, repeatV);
+}

--- a/js/mats/wall_glass.js
+++ b/js/mats/wall_glass.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/walls/glass/', repeatU, repeatV);
+}

--- a/js/mats/wall_osb.js
+++ b/js/mats/wall_osb.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/walls/osb/', repeatU, repeatV);
+}

--- a/js/mats/wall_plywood.js
+++ b/js/mats/wall_plywood.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/walls/plywood/', repeatU, repeatV);
+}

--- a/js/mats/wall_sip.js
+++ b/js/mats/wall_sip.js
@@ -1,0 +1,4 @@
+import { createMaterial } from './createMaterial.js';
+export default function(repeatU=1, repeatV=1){
+  return createMaterial('assets/textures/walls/sip/', repeatU, repeatV);
+}

--- a/mats.json
+++ b/mats.json
@@ -6,42 +6,42 @@
         {
           "name": "Wood",
           "materialID": "struct_wood",
-          "modelModule": "assets/models/structural/wood.js",
+          "modelModule": "js/mats/struct_wood.js",
           "textureDir": "assets/textures/structural/wood/",
           "textureDesc": "Seamless oak plank boards, warm honey-brown with visible straight grain, scattered knots, light edge wear, matte finish. PBR maps: albedo, packed normal/roughness/AO."
         },
         {
           "name": "Concrete",
           "materialID": "struct_concrete",
-          "modelModule": "assets/models/structural/concrete.js",
+          "modelModule": "js/mats/struct_concrete.js",
           "textureDir": "assets/textures/structural/concrete/",
           "textureDesc": "Poured gray concrete surface, fine sand aggregate, subtle trowel lines, tiny pockmarks, slight discoloration patches. Include roughness, height, and AO for depth."
         },
         {
           "name": "Steel",
           "materialID": "struct_steel",
-          "modelModule": "assets/models/structural/steel.js",
+          "modelModule": "js/mats/struct_steel.js",
           "textureDir": "assets/textures/structural/steel/",
           "textureDesc": "Galvanized structural I-beam steel, cool bluish tint, faint mill scale streaks, light scratches, low-gloss clear coat. Metalness, normal, and roughness maps required."
         },
         {
           "name": "Brick",
           "materialID": "struct_brick",
-          "modelModule": "assets/models/structural/brick.js",
+          "modelModule": "js/mats/struct_brick.js",
           "textureDir": "assets/textures/structural/brick/",
           "textureDesc": "Traditional red-orange clay bricks in running bond, sand-cement mortar joints, chipped edges, soot stains near top rows. Provide albedo, height, AO, roughness."
         },
         {
           "name": "Stone",
           "materialID": "struct_stone",
-          "modelModule": "assets/models/structural/stone.js",
+          "modelModule": "js/mats/struct_stone.js",
           "textureDir": "assets/textures/structural/stone/",
           "textureDesc": "Random ashlar granite blocks, light gray flecked with mica, deep mortar recesses, lichen speckles. Include high-res normal and height for rugged relief."
         },
         {
           "name": "Cement Board",
           "materialID": "struct_cementboard",
-          "modelModule": "assets/models/structural/cementBoard.js",
+          "modelModule": "js/mats/struct_cementboard.js",
           "textureDir": "assets/textures/structural/cementBoard/",
           "textureDesc": "Fiber-cement sheet, neutral gray, subtle fiber grain pattern, fine surface sand, hairline cracks. PBR: albedo, normal, roughness, AO for realism."
         }
@@ -53,35 +53,35 @@
         {
           "name": "Drywall",
           "materialID": "wall_drywall",
-          "modelModule": "assets/models/walls/drywall.js",
+          "modelModule": "js/mats/wall_drywall.js",
           "textureDir": "assets/textures/walls/drywall/",
           "textureDesc": "Paint-ready gypsum board, off-white, faint joint compound seams, tiny surface dimples, satin finish. Normal map subtle, roughness low-variance."
         },
         {
           "name": "Plywood",
           "materialID": "wall_plywood",
-          "modelModule": "assets/models/walls/plywood.js",
+          "modelModule": "js/mats/wall_plywood.js",
           "textureDir": "assets/textures/walls/plywood/",
           "textureDesc": "Construction-grade plywood sheet, alternating veneer grain, occasional football patches, warm tan color, matte. Provide seamless tiling, normal for grain relief."
         },
         {
           "name": "OSB",
           "materialID": "wall_osb",
-          "modelModule": "assets/models/walls/osb.js",
+          "modelModule": "js/mats/wall_osb.js",
           "textureDir": "assets/textures/walls/osb/",
           "textureDesc": "Oriented-strand board flakes, yellow-brown resin specks, random strand orientation, rough tactile surface. Height and normal should emphasize chip depth."
         },
         {
           "name": "Glass",
           "materialID": "wall_glass",
-          "modelModule": "assets/models/walls/glass.js",
+          "modelModule": "js/mats/wall_glass.js",
           "textureDir": "assets/textures/walls/glass/",
           "textureDesc": "Clear float glass pane, 2 mm grime along edges, micro-scratches, slight green tint at thickness. Roughness map minimal; include thin-film normal for realism."
         },
         {
           "name": "Insulated Panel",
           "materialID": "wall_sip",
-          "modelModule": "assets/models/walls/sip.js",
+          "modelModule": "js/mats/wall_sip.js",
           "textureDir": "assets/textures/walls/sip/",
           "textureDesc": "SIP cross-section: OSB faces with beveled foam core edge, light nail marks. Texture split: wood exterior, foam interior for cutaway visuals."
         }
@@ -93,28 +93,28 @@
         {
           "name": "Asphalt Shingles",
           "materialID": "roof_asphalt",
-          "modelModule": "assets/models/roofing/asphaltShingles.js",
+          "modelModule": "js/mats/roof_asphalt.js",
           "textureDir": "assets/textures/roofing/asphaltShingles/",
           "textureDesc": "Architectural asphalt shingles, dark charcoal granules, staggered courses, light moss flecks, granular height variance. Normal and roughness highlight grit."
         },
         {
           "name": "Metal Panels",
           "materialID": "roof_metal",
-          "modelModule": "assets/models/roofing/metalPanels.js",
+          "modelModule": "js/mats/roof_metal.js",
           "textureDir": "assets/textures/roofing/metalPanels/",
           "textureDesc": "Standing-seam metal roof, faded red paint, subtle panel ribs every 12 in, slight oil-canning waviness, fine rust specks near seams. Metalness workflow."
         },
         {
           "name": "Clay Tiles",
           "materialID": "roof_clay",
-          "modelModule": "assets/models/roofing/clayTiles.js",
+          "modelModule": "js/mats/roof_clay.js",
           "textureDir": "assets/textures/roofing/clayTiles/",
           "textureDesc": "Spanish barrel clay tiles, terracotta orange, weathered edges, scattered lichen, alternating convex rows. Height map for curved profile, roughness varied."
         },
         {
           "name": "Slate",
           "materialID": "roof_slate",
-          "modelModule": "assets/models/roofing/slate.js",
+          "modelModule": "js/mats/roof_slate.js",
           "textureDir": "assets/textures/roofing/slate/",
           "textureDesc": "Hand-split slate shingles, dark graphite gray, thin chips, overlapping pattern, subtle mica sparkle. Include high-detail normal for layered edges."
         }
@@ -126,35 +126,35 @@
         {
           "name": "Wood Siding",
           "materialID": "siding_wood",
-          "modelModule": "assets/models/siding/woodSiding.js",
+          "modelModule": "js/mats/siding_wood.js",
           "textureDir": "assets/textures/claddingAndSiding/woodSiding/",
           "textureDesc": "Horizontal cedar clapboards, semi-transparent stain, visible grain, slight warping, nail heads flush. Provide tiling seamlessness, normal for board overlap."
         },
         {
           "name": "Vinyl Siding",
           "materialID": "siding_vinyl",
-          "modelModule": "assets/models/siding/vinylSiding.js",
+          "modelModule": "js/mats/siding_vinyl.js",
           "textureDir": "assets/textures/siding/vinylSiding/",
           "textureDesc": "Double-lap vinyl panels, light beige, subtle woodgrain emboss, interlocking seams with shadow gaps. Roughness low, normal gentle for emboss depth."
         },
         {
           "name": "Fiber Cement",
           "materialID": "siding_fiberCement",
-          "modelModule": "assets/models/siding/fiberCement.js",
+          "modelModule": "js/mats/siding_fiberCement.js",
           "textureDir": "assets/textures/siding/fiberCement/",
           "textureDesc": "Fiber-cement planks, factory-primed gray, faint linear fiber striations, beveled drip edge. Include normal and slight speckled roughness variation."
         },
         {
           "name": "Stucco",
           "materialID": "siding_stucco",
-          "modelModule": "assets/models/siding/stucco.js",
+          "modelModule": "js/mats/siding_stucco.js",
           "textureDir": "assets/textures/siding/stucco/",
           "textureDesc": "Traditional sand-cement stucco, off-white, medium float finish, random trowel swirls, occasional hairline cracks. Height and normal subtle but present."
         },
         {
           "name": "Brick Veneer",
           "materialID": "siding_brickVeneer",
-          "modelModule": "assets/models/siding/brickVeneer.js",
+          "modelModule": "js/mats/siding_brickVeneer.js",
           "textureDir": "assets/textures/siding/brickVeneer/",
           "textureDesc": "Modular brick veneer, deep red mix, tight mortar joints, occasional soot stains, chips on corners. Provide crisp normal for joint recess depth."
         }
@@ -166,28 +166,28 @@
         {
           "name": "Hardwood",
           "materialID": "int_hardwood",
-          "modelModule": "assets/models/interior/hardwood.js",
+          "modelModule": "js/mats/int_hardwood.js",
           "textureDir": "assets/textures/interior/hardwood/",
           "textureDesc": "Seamless maple floorboards, light amber, tight seams, satin polyurethane gloss, subtle wear scratches near edges. PBR with roughness/gloss variation."
         },
         {
           "name": "Ceramic Tile",
           "materialID": "int_ceramicTile",
-          "modelModule": "assets/models/interior/ceramicTile.js",
+          "modelModule": "js/mats/int_ceramicTile.js",
           "textureDir": "assets/textures/interior/ceramicTile/",
           "textureDesc": "12\"x12\" matte porcelain tiles, cool gray, faint mottled pattern, 1/8\" light-gray grout lines recessed. Normal emphasises grout depth, low roughness."
         },
         {
           "name": "Carpet",
           "materialID": "int_carpet",
-          "modelModule": "assets/models/interior/carpet.js",
+          "modelModule": "js/mats/int_carpet.js",
           "textureDir": "assets/textures/interior/carpet/",
           "textureDesc": "Short-pile nylon carpet, neutral taupe, uniform fibers, subtle directional shading, no stains. Height map tiny, roughness high for soft feel."
         },
         {
           "name": "Plaster",
           "materialID": "int_plaster",
-          "modelModule": "assets/models/interior/plaster.js",
+          "modelModule": "js/mats/int_plaster.js",
           "textureDir": "assets/textures/interior/plaster/",
           "textureDesc": "Smooth wall plaster, eggshell white, micro-pitting, faint roller marks, slight sheen. Normal minimal, roughness smooth with tiny variation."
         }


### PR DESCRIPTION
## Summary
- add a reusable `createMaterial` helper
- generate per-material modules under `js/mats`
- reference those modules in `mats.json`
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815da3ce208332bf4d76434b39b8b1