### PR TITLE
Add animated sprite NPC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-07-23
+- 1621 Added "Use Animated Sprites" option with new sprite models and animations
 - 2214 Break Game.js into smaller initialization modules for easier maintenance
 - 0000 Rewrite mats.json to load building modules from `js/mats`
 

--- a/assets.json
+++ b/assets.json
@@ -236,5 +236,26 @@
       "name": "Knight Listening Animation",
       "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Public/Armored%20Knight/Animation_Listening_Gesture_withSkin.glb"
     }
+    ,
+    {
+      "type": "model",
+      "name": "Sprite Idle Animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Public/Sprite/Animation_Idle_6_withSkin.glb"
+    },
+    {
+      "type": "model",
+      "name": "Sprite Walking Animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Public/Sprite/Animation_Walking_withSkin.glb"
+    },
+    {
+      "type": "model",
+      "name": "Sprite Running Animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Public/Sprite/Animation_Running_withSkin.glb"
+    },
+    {
+      "type": "model",
+      "name": "Sprite Listening Animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Public/Sprite/Animation_Listening_Gesture_withSkin.glb"
+    }
   ]
 }

--- a/js/animationSetup.js
+++ b/js/animationSetup.js
@@ -263,6 +263,35 @@ export function setupAnimatedKnight(model, idleClip, walkClip, runClip, listenCl
     return model;
 }
 
+export function setupAnimatedSprite(model, idleClip, walkClip, runClip, listenClip) {
+    idleClip.name = "idle";
+    walkClip.name = "walk";
+    runClip.name = "run";
+    listenClip.name = "listen";
+
+    model.animations = [idleClip, walkClip, runClip, listenClip];
+
+    const mixer = new THREE.AnimationMixer(model);
+    const actions = {
+        idle: mixer.clipAction(idleClip),
+        walk: mixer.clipAction(walkClip),
+        run: mixer.clipAction(runClip),
+        listen: mixer.clipAction(listenClip),
+    };
+
+    model.userData.animationFadeDuration = 0.4;
+    actions.idle.play();
+
+    const rotationOffset = 0;
+    model.userData.rotationOffset = rotationOffset;
+
+    model.userData.mixer = mixer;
+    model.userData.actions = actions;
+    model.userData.isAnimatedGLB = true;
+
+    return model;
+}
+
 export function setupEyebot(model) {
     model.userData.isEyebot = true;
     model.userData.isAnimatedGLB = false; // It is not using baked animations

--- a/js/assetReplacementManager.js
+++ b/js/assetReplacementManager.js
@@ -1,6 +1,6 @@
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { Downloader } from './downloader.js';
-import { setupAnimatedPlayer, setupAnimatedRobot, setupAnimatedChicken, setupAnimatedWireframe, setupAnimatedAlien, setupEyebot, setupAnimatedShopkeeper, setupAnimatedOgre, setupAnimatedKnight } from './animationSetup.js';
+import { setupAnimatedPlayer, setupAnimatedRobot, setupAnimatedChicken, setupAnimatedWireframe, setupAnimatedAlien, setupEyebot, setupAnimatedShopkeeper, setupAnimatedOgre, setupAnimatedKnight, setupAnimatedSprite } from './animationSetup.js';
 
 export class AssetReplacementManager {
     /* @tweakable The number of models to parse in parallel. Higher values may be faster but use more memory and CPU. */
@@ -56,6 +56,12 @@ export class AssetReplacementManager {
                 clipNames: ['idle', 'walk', 'listen'],
                 setupFn: setupAnimatedShopkeeper,
                 applyFn: (modelData) => this.dependencies.npcManager.useAnimatedShopkeepers(modelData)
+            },
+            "sprite": {
+                assetNames: ["Sprite Idle Animation", "Sprite Walking Animation", "Sprite Running Animation", "Sprite Listening Animation"],
+                clipNames: ["idle", "walk", "run", "listen"],
+                setupFn: setupAnimatedSprite,
+                applyFn: (modelData) => this.dependencies.npcManager.useAnimatedSprites(modelData)
             },
             'ogre': {
                 assetNames: ['Ogre Idle Animation', 'Ogre Walking Animation', 'Ogre Running Animation', 'Ogre Listening Animation'],

--- a/js/characters/presets.js
+++ b/js/characters/presets.js
@@ -6,6 +6,7 @@ import { alienPreset } from './presets/alien.js';
 import { shopkeeperPreset } from './presets/shopkeeper.js';
 import { golemPreset } from './presets/golem.js';
 import { plantCreaturePreset } from './presets/plantCreature.js';
+import { spritePreset } from "./presets/sprite.js";
 import { slimePreset } from './presets/slime.js';
 import { ghostPreset } from './presets/ghost.js';
 import { knightPreset } from './presets/knight.js';
@@ -14,6 +15,7 @@ import { nursePreset } from './presets/nurse.js';
 import { tavernkeepPreset } from './presets/tavernkeep.js';
 
 export const presetCharacters = [
+  spritePreset,
   robotsPreset,
   chickenPreset,
   eyebotPreset,

--- a/js/characters/presets/sprite.js
+++ b/js/characters/presets/sprite.js
@@ -1,0 +1,65 @@
+export const spritePreset = {
+  id: "sprite",
+  name: "Forest Sprite",
+  description: "A being of leaf and vine.",
+  spec: {
+    customMode: true,
+    features: [
+      // Body (Vine)
+      {
+        type: "cylinder",
+        /* @tweakable The color of the Forest Sprite's vine body. */
+        color: "#4A3728",
+        position: { x: 0, y: 0.7, z: 0 },
+        scale: { x: 0.2, y: 1.4, z: 0.2 },
+      },
+      // Head
+      {
+        type: "sphere",
+        /* @tweakable The color of the Forest Sprite's head. */
+        color: "#6B8E23",
+        position: { x: 0, y: 1.5, z: 0 },
+        scale: { x: 0.4, y: 0.4, z: 0.4 },
+      },
+      // Flower on head
+      {
+        type: "cone",
+        /* @tweakable The color of the flower on the Forest Sprite's head. */
+        color: "#FFD700",
+        position: { x: 0, y: 1.8, z: 0 },
+        scale: { x: 0.3, y: 0.2, z: 0.3 },
+        rotation: { x: Math.PI, y: 0, z: 0 },
+      },
+      // Legs
+      {
+        type: "cylinder",
+        name: "leftLeg",
+        color: "#4A3728",
+        position: { x: -0.1, y: 0, z: 0 },
+        scale: { x: 0.1, y: 0.6, z: 0.1 },
+      },
+      {
+        type: "cylinder",
+        name: "rightLeg",
+        color: "#4A3728",
+        position: { x: 0.1, y: 0, z: 0 },
+        scale: { x: 0.1, y: 0.6, z: 0.1 },
+      },
+      // Leaves
+      {
+        type: "box",
+        color: "#228B22",
+        position: { x: -0.3, y: 1, z: 0 },
+        scale: { x: 0.6, y: 0.1, z: 0.4 },
+        rotation: { x: 0, y: 0.5, z: 0.3 },
+      },
+      {
+        type: "box",
+        color: "#228B22",
+        position: { x: 0.3, y: 0.8, z: 0 },
+        scale: { x: 0.6, y: 0.1, z: 0.4 },
+        rotation: { x: 0, y: -0.5, z: -0.3 },
+      },
+    ],
+  },
+};

--- a/js/npc/NPCSpawner.js
+++ b/js/npc/NPCSpawner.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { createPlayerModel } from '../playerModel.js';
-import { setupAnimatedRobot, setupEyebot, setupAnimatedChicken, setupAnimatedWireframe, setupAnimatedAlien, setupAnimatedShopkeeper, setupAnimatedOgre, setupAnimatedKnight } from '../animationSetup.js';
+import { setupAnimatedRobot, setupEyebot, setupAnimatedChicken, setupAnimatedWireframe, setupAnimatedAlien, setupAnimatedShopkeeper, setupAnimatedOgre, setupAnimatedKnight, setupAnimatedSprite } from '../animationSetup.js';
 import { presetCharacters } from '../characters/presets.js';
 import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 import { NPC } from './NPC.js';
@@ -10,6 +10,7 @@ import {
     EYEBOT_SPAWN_CHANCE,
     OGRE_SPAWN_CHANCE,
     KNIGHT_SPAWN_CHANCE,
+    SPRITE_SPAWN_CHANCE,
     NPC_ADJECTIVES,
     MIN_NPCS_PER_ZONE,
     MAX_NPCS_PER_ZONE,
@@ -20,6 +21,7 @@ import {
     SHOPKEEPER_NPC_SCALE,
     OGRE_NPC_SCALE,
     KNIGHT_NPC_SCALE,
+    SPRITE_NPC_SCALE,
     EYEBOT_NPC_SCALE,
     EYEBOT_FLY_HEIGHT,
     FIX_FRUSTUM_CULLING_BUG
@@ -110,6 +112,14 @@ export class NPCSpawner {
                 npcModel.traverse(c => { c.castShadow = true; });
                 npcModel.scale.set(CHICKEN_NPC_SCALE, CHICKEN_NPC_SCALE, CHICKEN_NPC_SCALE);
             }
+            else if (this.animatedData.sprite && this.animatedData.sprite.model && Math.random() < SPRITE_SPAWN_CHANCE) {
+                preset = presetCharacters.find(p => p.id === "sprite");
+                const spriteData = this.animatedData.sprite;
+                npcModel = SkeletonUtils.clone(spriteData.model);
+                spriteData.setupFn(npcModel, spriteData.idleClip, spriteData.walkClip, spriteData.runClip, spriteData.listenClip);
+                npcModel.name = `${adjective} Sprite`;
+                npcModel.traverse(c => { c.castShadow = true; });
+            }
             else if (this.animatedData.ogre && this.animatedData.ogre.model && Math.random() < OGRE_SPAWN_CHANCE) {
                 preset = presetCharacters.find(p => p.id === 'ogre');
                 const ogreData = this.animatedData.ogre;
@@ -150,6 +160,9 @@ export class NPCSpawner {
                 }
                 if (this.animatedData.knight) {
                     availablePresets = availablePresets.filter(p => p.id !== 'knight');
+                }
+                if (this.animatedData.sprite) {
+                    availablePresets = availablePresets.filter(p => p.id !== 'sprite');
                 }
                 
                 // Exclude the unique shopkeeper from random spawning
@@ -276,6 +289,7 @@ export class NPCSpawner {
                 case 'wireframe': newModel.name = `${adjective} Wireframe`; scale = WIREFRAME_NPC_SCALE; break;
                 case 'alien': newModel.name = `${adjective} Alien`; scale = ALIEN_NPC_SCALE; break;
                 case 'shopkeeper': newModel.name = `Shopkeeper`; scale = SHOPKEEPER_NPC_SCALE; break;
+                case 'sprite': newModel.name = `${adjective} Sprite`; scale = SPRITE_NPC_SCALE; break;
                 case 'ogre': newModel.name = `${adjective} Ogre`; scale = OGRE_NPC_SCALE; break;
                 case 'knight': newModel.name = `${adjective} Knight`; scale = KNIGHT_NPC_SCALE; break;
             }

--- a/js/npc/constants.js
+++ b/js/npc/constants.js
@@ -19,6 +19,8 @@ export const OGRE_SPAWN_CHANCE = 0.15;
 /* @tweakable The chance (from 0 to 1) that a spawned NPC will be a knight when animated knights are enabled. */
 export const KNIGHT_SPAWN_CHANCE = 0.15;
 /* @tweakable Adjectives to describe NPCs. An adjective is randomly picked from this list. */
+/* @tweakable The chance (from 0 to 1) that a spawned NPC will be a sprite when animated sprites are enabled. */
+export const SPRITE_SPAWN_CHANCE = 0.2;
 export const NPC_ADJECTIVES = ["Wandering", "Mysterious", "Lost", "Curious", "Silent", "Ancient", "Jolly", "Grumpy"];
 /* @tweakable Min NPCs per zone. */
 export const MIN_NPCS_PER_ZONE = 1;
@@ -42,6 +44,8 @@ export const SHOPKEEPER_NPC_SCALE = 1.0;
 export const OGRE_NPC_SCALE = 1.2;
 /* @tweakable The scale of the animated knight NPCs. */
 export const KNIGHT_NPC_SCALE = 1.0;
+/* @tweakable The scale of the animated sprite NPCs. */
+export const SPRITE_NPC_SCALE = 1.0;
 /* @tweakable The scale of the eyebot NPCs. */
 export const EYEBOT_NPC_SCALE = 0.25;
 /* @tweakable Base height of eyebots above terrain. */

--- a/js/npcManager.js
+++ b/js/npcManager.js
@@ -95,6 +95,13 @@ export class NPCManager {
             this.npcSpawner.replaceNpcModels('knight');
         }
     }
+    useAnimatedSprites(data, replaceExisting = true) {
+        this.npcSpawner.setAnimatedData("sprite", data);
+        if (replaceExisting) {
+            this.npcSpawner.replaceNpcModels("sprite");
+        }
+    }
+
 
     activateZone(zoneKey) {
         if (!this.npcSpawner) return; // Don't spawn if spawner isn't ready

--- a/ui/options/assetControls.js
+++ b/ui/options/assetControls.js
@@ -43,6 +43,9 @@ export function setupAssetControls(modal, assetReplacementManager) {
     modal.querySelector('#replace-ogres-button').addEventListener('click', () => {
         assetReplacementManager.replaceModel('ogre');
     });
+    modal.querySelector('#replace-sprites-button').addEventListener('click', () => {
+        assetReplacementManager.replaceModel('sprite');
+    });
     modal.querySelector('#replace-knights-button').addEventListener('click', () => {
         assetReplacementManager.replaceModel('knight');
     });

--- a/ui/optionsUI.js
+++ b/ui/optionsUI.js
@@ -76,6 +76,7 @@ export class OptionsUI {
                         <button class="option-button" id="replace-wireframes-button" data-tooltip="Replace wireframe NPCs with animated models">Use Animated Wireframes</button>
                         <button class="option-button" id="replace-aliens-button" data-tooltip="Replace alien NPCs with animated models">Use Animated Aliens</button>
                         <button class="option-button" id="replace-shopkeeper-button" data-tooltip="Replace shopkeeper NPC with an animated model">Use Animated Shopkeeper</button>
+                        <button class="option-button" id="replace-sprites-button" data-tooltip="Replace sprite NPCs with animated models">Use Animated Sprites</button>
                         <button class="option-button" id="replace-ogres-button" data-tooltip="Replace ogre NPCs with animated models">Use Animated Ogres</button>
                         <button class="option-button" id="replace-knights-button" data-tooltip="Replace knight NPCs with animated models">Use Animated Knights</button>
                     </div>


### PR DESCRIPTION
## Summary
- add a new sprite preset
- wire up "Use Animated Sprites" button in options
- support sprite assets in asset manager
- spawn animated sprites
- document in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68816bc7157083329b805dfa34fa5c5a