### PR TITLE
Add crowd NPC presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 # Changelog
 
-## 2025-07-24
-- 1609 Added kitbashing material generator and regenerated js/mats modules
-- 1504 Split amphitheatre.js into smaller modules
-- 1551 Added houseItems.js with 25 kitbashed furniture items
-
+## 2025-07-25
+- 1446 Added crowd NPC presets for robots, humans and aliens
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -1,4 +1,9 @@
 # Changelog Archive
+## 2025-07-24
+- 1609 Added kitbashing material generator and regenerated js/mats modules
+- 1504 Split amphitheatre.js into smaller modules
+- 1551 Added houseItems.js with 25 kitbashed furniture items
+
 
 ## 2025-07-23
 - 1621 Added "Use Animated Sprites" option with new sprite models and animations

--- a/js/characters/presets.js
+++ b/js/characters/presets.js
@@ -13,6 +13,21 @@ import { knightPreset } from './presets/knight.js';
 import { ogrePreset } from './presets/ogre.js';
 import { nursePreset } from './presets/nurse.js';
 import { tavernkeepPreset } from './presets/tavernkeep.js';
+import { crowdBot1Preset } from "./presets/crowdBot1.js";
+import { crowdBot2Preset } from "./presets/crowdBot2.js";
+import { crowdBot3Preset } from "./presets/crowdBot3.js";
+import { crowdBot4Preset } from "./presets/crowdBot4.js";
+import { crowdBot5Preset } from "./presets/crowdBot5.js";
+import { crowdFemale1Preset } from "./presets/crowdFemale1.js";
+import { crowdFemale2Preset } from "./presets/crowdFemale2.js";
+import { crowdFemale3Preset } from "./presets/crowdFemale3.js";
+import { crowdMale1Preset } from "./presets/crowdMale1.js";
+import { crowdMale2Preset } from "./presets/crowdMale2.js";
+import { crowdMale3Preset } from "./presets/crowdMale3.js";
+import { crowdAlien1Preset } from "./presets/crowdAlien1.js";
+import { crowdAlien2Preset } from "./presets/crowdAlien2.js";
+import { crowdAlien3Preset } from "./presets/crowdAlien3.js";
+import { crowdAlien4Preset } from "./presets/crowdAlien4.js";
 
 export const presetCharacters = [
   spritePreset,
@@ -29,7 +44,22 @@ export const presetCharacters = [
   knightPreset,
   ogrePreset,
   nursePreset,
-  tavernkeepPreset
+  tavernkeepPreset,
+  crowdBot1Preset,
+  crowdBot2Preset,
+  crowdBot3Preset,
+  crowdBot4Preset,
+  crowdBot5Preset,
+  crowdFemale1Preset,
+  crowdFemale2Preset,
+  crowdFemale3Preset,
+  crowdMale1Preset,
+  crowdMale2Preset,
+  crowdMale3Preset,
+  crowdAlien1Preset,
+  crowdAlien2Preset,
+  crowdAlien3Preset,
+  crowdAlien4Preset
 ];
 
 export { availableTextures } from './textures.js';

--- a/js/characters/presets/crowdAlien1.js
+++ b/js/characters/presets/crowdAlien1.js
@@ -1,0 +1,7 @@
+import { alienPreset } from './alien.js';
+export const crowdAlien1Preset = {
+  id: 'crowd_alien_1',
+  name: 'Crowd Alien 1',
+  description: 'A generic crowd alien variant 1.',
+  spec: alienPreset.spec
+};

--- a/js/characters/presets/crowdAlien2.js
+++ b/js/characters/presets/crowdAlien2.js
@@ -1,0 +1,7 @@
+import { alienPreset } from './alien.js';
+export const crowdAlien2Preset = {
+  id: 'crowd_alien_2',
+  name: 'Crowd Alien 2',
+  description: 'A generic crowd alien variant 2.',
+  spec: alienPreset.spec
+};

--- a/js/characters/presets/crowdAlien3.js
+++ b/js/characters/presets/crowdAlien3.js
@@ -1,0 +1,7 @@
+import { alienPreset } from './alien.js';
+export const crowdAlien3Preset = {
+  id: 'crowd_alien_3',
+  name: 'Crowd Alien 3',
+  description: 'A generic crowd alien variant 3.',
+  spec: alienPreset.spec
+};

--- a/js/characters/presets/crowdAlien4.js
+++ b/js/characters/presets/crowdAlien4.js
@@ -1,0 +1,7 @@
+import { alienPreset } from './alien.js';
+export const crowdAlien4Preset = {
+  id: 'crowd_alien_4',
+  name: 'Crowd Alien 4',
+  description: 'A generic crowd alien variant 4.',
+  spec: alienPreset.spec
+};

--- a/js/characters/presets/crowdBot1.js
+++ b/js/characters/presets/crowdBot1.js
@@ -1,0 +1,7 @@
+import { robotsPreset } from './robots.js';
+export const crowdBot1Preset = {
+  id: 'crowd_bot_1',
+  name: 'Crowd Bot 1',
+  description: 'A generic crowd robot variant 1.',
+  spec: robotsPreset.spec
+};

--- a/js/characters/presets/crowdBot2.js
+++ b/js/characters/presets/crowdBot2.js
@@ -1,0 +1,7 @@
+import { robotsPreset } from './robots.js';
+export const crowdBot2Preset = {
+  id: 'crowd_bot_2',
+  name: 'Crowd Bot 2',
+  description: 'A generic crowd robot variant 2.',
+  spec: robotsPreset.spec
+};

--- a/js/characters/presets/crowdBot3.js
+++ b/js/characters/presets/crowdBot3.js
@@ -1,0 +1,7 @@
+import { robotsPreset } from './robots.js';
+export const crowdBot3Preset = {
+  id: 'crowd_bot_3',
+  name: 'Crowd Bot 3',
+  description: 'A generic crowd robot variant 3.',
+  spec: robotsPreset.spec
+};

--- a/js/characters/presets/crowdBot4.js
+++ b/js/characters/presets/crowdBot4.js
@@ -1,0 +1,7 @@
+import { robotsPreset } from './robots.js';
+export const crowdBot4Preset = {
+  id: 'crowd_bot_4',
+  name: 'Crowd Bot 4',
+  description: 'A generic crowd robot variant 4.',
+  spec: robotsPreset.spec
+};

--- a/js/characters/presets/crowdBot5.js
+++ b/js/characters/presets/crowdBot5.js
@@ -1,0 +1,7 @@
+import { robotsPreset } from './robots.js';
+export const crowdBot5Preset = {
+  id: 'crowd_bot_5',
+  name: 'Crowd Bot 5',
+  description: 'A generic crowd robot variant 5.',
+  spec: robotsPreset.spec
+};

--- a/js/characters/presets/crowdFemale1.js
+++ b/js/characters/presets/crowdFemale1.js
@@ -1,0 +1,7 @@
+import { nursePreset } from './nurse.js';
+export const crowdFemale1Preset = {
+  id: 'crowd_female_1',
+  name: 'Crowd Female 1',
+  description: 'A generic crowd female variant 1.',
+  spec: nursePreset.spec
+};

--- a/js/characters/presets/crowdFemale2.js
+++ b/js/characters/presets/crowdFemale2.js
@@ -1,0 +1,7 @@
+import { nursePreset } from './nurse.js';
+export const crowdFemale2Preset = {
+  id: 'crowd_female_2',
+  name: 'Crowd Female 2',
+  description: 'A generic crowd female variant 2.',
+  spec: nursePreset.spec
+};

--- a/js/characters/presets/crowdFemale3.js
+++ b/js/characters/presets/crowdFemale3.js
@@ -1,0 +1,7 @@
+import { nursePreset } from './nurse.js';
+export const crowdFemale3Preset = {
+  id: 'crowd_female_3',
+  name: 'Crowd Female 3',
+  description: 'A generic crowd female variant 3.',
+  spec: nursePreset.spec
+};

--- a/js/characters/presets/crowdMale1.js
+++ b/js/characters/presets/crowdMale1.js
@@ -1,0 +1,7 @@
+import { knightPreset } from './knight.js';
+export const crowdMale1Preset = {
+  id: 'crowd_male_1',
+  name: 'Crowd Male 1',
+  description: 'A generic crowd male variant 1.',
+  spec: knightPreset.spec
+};

--- a/js/characters/presets/crowdMale2.js
+++ b/js/characters/presets/crowdMale2.js
@@ -1,0 +1,7 @@
+import { knightPreset } from './knight.js';
+export const crowdMale2Preset = {
+  id: 'crowd_male_2',
+  name: 'Crowd Male 2',
+  description: 'A generic crowd male variant 2.',
+  spec: knightPreset.spec
+};

--- a/js/characters/presets/crowdMale3.js
+++ b/js/characters/presets/crowdMale3.js
@@ -1,0 +1,7 @@
+import { knightPreset } from './knight.js';
+export const crowdMale3Preset = {
+  id: 'crowd_male_3',
+  name: 'Crowd Male 3',
+  description: 'A generic crowd male variant 3.',
+  spec: knightPreset.spec
+};


### PR DESCRIPTION
## Summary
- add preset modules for crowd bots, humans, and aliens
- enable new presets in `presetCharacters`
- move older changelog entries to archive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883fa52044c8332b5c2806e0b241d4d