### PR TITLE
Fix global collision handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-07-29
+- 1013 Make collision detection include players and ignore self-object
 - 0953 Break up trees.js into separate tree modules
 
 ## Guidelines for future updates

--- a/js/collisionManager.js
+++ b/js/collisionManager.js
@@ -62,14 +62,15 @@ export class CollisionManager {
      *  standingOnBlock: boolean
      * }}
      */
-    checkCollisions(currentPosition, proposedPosition, velocity, playerRadius, playerHeight) {
+    checkCollisions(currentPosition, proposedPosition, velocity, playerRadius, playerHeight, selfObject = null) {
         const blockMeshes = [];
         const worldPosition = new THREE.Vector3();
 
         this.scene.traverse(child => {
             // This is a more robust way of collecting collidable objects,
             // as it checks the entire scene graph, not just direct children.
-            if ((child.userData.isBlock || child.userData.isBarrier || (child.type === "Group" && child.userData.isTree) || child.userData.isNpc) && child.userData.isCollidable !== false) {
+            if (child === selfObject) return;
+            if ((child.userData.isBlock || child.userData.isBarrier || (child.type === "Group" && child.userData.isTree) || child.userData.isNpc || child.userData.isPlayer) && child.userData.isCollidable !== false) {
                 child.getWorldPosition(worldPosition);
                 /* @tweakable The distance from the player to check for collidable objects. Lowering may improve performance but can cause missed collisions with large objects. */
                 const effectiveCollisionRadius = COLLISION_CHECK_RADIUS + (child.geometry?.boundingSphere?.radius || 0);

--- a/js/npc/NPC.js
+++ b/js/npc/NPC.js
@@ -225,7 +225,8 @@ export class NPC {
                                 proposedPosition,
                                 new THREE.Vector3(), // Velocity is not used for simple NPC movement
                                 this.collisionRadius,
-                                this.collisionHeight
+                                this.collisionHeight,
+                                this.model
                             );
                             finalPosition = result.finalPosition;
                         }

--- a/js/player/processMovement.js
+++ b/js/player/processMovement.js
@@ -172,7 +172,8 @@ export function processMovement(pc, delta) {
           new THREE.Vector3(newX, newY, newZ),
           pc.velocity,
           PLAYER_COLLISION_RADIUS,
-          PLAYER_COLLISION_HEIGHT
+          PLAYER_COLLISION_HEIGHT,
+          pc.playerModel
       );
       
       newX = finalPosition.x;


### PR DESCRIPTION
## Summary
- add a `selfObject` parameter to `CollisionManager.checkCollisions` and account for player models
- pass the player or NPC model to `checkCollisions` when testing movement
- include players when gathering collidable objects
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890073b9b4833285565eae4cbca27a