### PR TITLE
Implement 500-char changelog rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Read them all before contributing:
 
 Key points:
 
-- Update `CHANGELOG.md` for every change using UTC-7 dates and an `HHMM` prefix for each bullet.
+- Update `CHANGELOG.md` for every change using UTC-7 dates and an `HHMM` prefix for each bullet. Each bullet must contain at least five hundred characters so that context, motivation and implications are clear.
 - `CHANGELOG.md` should contain only entries from the current UTC day. Move all older entries to `CHANGELOG_ARCHIVE.md`.
 - Run `npm test` or any project-specific tests before committing. Document test issues caused by environment limits in the pull request.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,8 @@
 # Changelog
 
-## 2025-07-29
+## 2025-07-30
 
-- 1611 Refactor advancedBuildTool.js into ColorManager module
-- 1610 Add billboard audio selection and Who Are You lyrics
-- 1400 Expand world size to 2000x2000 and adjust grid/object density to prevent lag.
-- 1357 Break up amphi-seats.js into smaller modules
-- 1013 Make collision detection include players and ignore self-object
-- 0953 Break up trees.js into separate tree modules
-- 1012 Convert global water plane to local pools with 1m recess
+- 1318 Documented a major revision to the repository's contribution guidelines. The AGENTS.md file now clarifies that each new entry in CHANGELOG.md must contain a description that is at least five hundred characters long. This update is mirrored in agents/changelog.md and ensures future changes are fully explained, including context, rationale and any required follow-up actions, so developers can reproduce results with minimal confusion. We also moved previous updates from July twenty-ninth into the archive so that the daily changelog only reflects the most recent work.
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -1,6 +1,14 @@
 # Changelog Archive
 ## 2025-07-30
 - 1100 Expand grass generation to cover the entire world within biome-specific rules, removing the central grass-only circle.
+## 2025-07-29
+- 1611 Refactor advancedBuildTool.js into ColorManager module
+- 1610 Add billboard audio selection and Who Are You lyrics
+- 1400 Expand world size to 2000x2000 and adjust grid/object density to prevent lag.
+- 1357 Break up amphi-seats.js into smaller modules
+- 1013 Make collision detection include players and ignore self-object
+- 0953 Break up trees.js into separate tree modules
+- 1012 Convert global water plane to local pools with 1m recess
 ## 2025-07-26
 - 1042 Split assets.json into external category lists and update loader
 - 1008 Move assets.json and mats.json into json directory and update paths.

--- a/agents/changelog.md
+++ b/agents/changelog.md
@@ -11,4 +11,4 @@
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).
 - Use a heading for each version or date, followed by brief bullet points.
-- Summaries should be short, highlighting major additions or fixes.
+- Summaries should be short, highlighting major additions or fixes. Each bullet must contain at least five hundred characters to provide sufficient detail.


### PR DESCRIPTION
## Summary
- document requirement for 500 character changelog bullets in `AGENTS.md`
- clarify the same rule in `agents/changelog.md`
- move 2025-07-29 changelog entries to `CHANGELOG_ARCHIVE.md`
- add a lengthy changelog bullet describing the update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7d9509ec8332909e2d63d52af1af