### PR TITLE
chore: split custom styles into modules

### DIFF
--- a/css/datastream.css
+++ b/css/datastream.css
@@ -1,0 +1,35 @@
+/* Datastream animation and terminal text styles */
+#datastream {
+  font-family:
+    JetBrains Mono,
+    monospace;
+  color: hsl(var(--primary));
+  text-align: center;
+  margin-top: 6rem;
+  min-height: 200px;
+  transition: opacity 1s ease;
+  position: relative;
+}
+#datastream.fade-out {
+  opacity: 0;
+}
+.typewriter {
+  white-space: pre-line;
+}
+.cursor {
+  display: inline-block;
+  width: 1ch;
+  background: hsl(var(--primary));
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.1%,
+  to {
+    opacity: 0;
+  }
+}

--- a/css/dossier.css
+++ b/css/dossier.css
@@ -1,18 +1,4 @@
-/* Base styles for the Lord Tsarcasm terminal interface */
-#datastream {
-  font-family:
-    JetBrains Mono,
-    monospace;
-  color: hsl(var(--primary));
-  text-align: center;
-  margin-top: 6rem;
-  min-height: 200px;
-  transition: opacity 1s ease;
-  position: relative;
-}
-#datastream.fade-out {
-  opacity: 0;
-}
+/* Dossier container and progress bar styles */
 .dossier-container {
   max-width: 800px;
   margin: 0 auto;
@@ -56,26 +42,6 @@
 .dossier-item {
   padding-left: 1rem;
   line-height: 1.4;
-}
-.typewriter {
-  white-space: pre-line;
-}
-.cursor {
-  display: inline-block;
-  width: 1ch;
-  background: hsl(var(--primary));
-  margin-left: 2px;
-  animation: blink 1s step-end infinite;
-}
-@keyframes blink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  50.1%,
-  to {
-    opacity: 0;
-  }
 }
 .redacted {
   color: hsl(var(--destructive));

--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-        <link rel="stylesheet" href="css/custom.css" />
+        <link rel="stylesheet" href="css/datastream.css" />
+        <link rel="stylesheet" href="css/dossier.css" />
         <link rel="stylesheet" href="css/utilities.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- refactor styles into dedicated datastream and dossier CSS files
- update HTML to load new style sheets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689185ddde8c8332a719338fc44d57d2