### PR TITLE
Add missing DOCTYPE to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- Ensure index page uses HTML standards mode by adding the missing `<!DOCTYPE html>` declaration.

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6893b98b489c8332a850c86ff5227204