### PR TITLE
style: isolate music page styles

### DIFF
--- a/src/music.css
+++ b/src/music.css
@@ -1,0 +1,19 @@
+.music-page dialog {
+  z-index: 50;
+}
+
+.music-page dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.music-page .waveform {
+  overflow: hidden;
+}
+
+.music-page .waveform img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Play, Pause, ExternalLink, Download, Heart, Share2 } from "lucide-react";
 import { SongCatalogSection } from "@/components/SongCatalogSection";
+import "../music.css";
 
 interface Track {
   id: string;
@@ -95,7 +96,7 @@ export const Music = () => {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8 space-y-8">
+    <div className="music-page container mx-auto px-4 py-8 space-y-8">
       {/* Header */}
       <div className="text-center space-y-4">
         <h1 className="title-text text-4xl md:text-6xl font-black glow-text">
@@ -183,7 +184,7 @@ export const Music = () => {
                     </div>
                   </div>
 
-                  <div className="terminal-text text-primary text-lg font-mono tracking-wider">
+                  <div className="waveform terminal-text text-primary text-lg font-mono tracking-wider">
                     {track.waveform}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add dedicated music.css with dialog and waveform fixes
- import new styles in Music.tsx and scope page elements

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6893c44ab7608332af37391eb4eab338