### PR TITLE
Rename 3D Overworld project to 3D Concerts

### DIFF
--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -45,7 +45,7 @@ const projects: Project[] = [
   },
   {
     id: "far-haven-map",
-    title: "3D Overworld",
+    title: "3D Concerts",
     description: "Explore the ruined megacity through an interactive, lore-rich digital map.",
     longDescription: "Navigate the districts of Far Haven, from the gleaming Corporate Spires to the shadowy Undercity. Each location contains hidden stories, faction territories, and secrets waiting to be discovered.",
     category: "Web",


### PR DESCRIPTION
## Summary
- rename 3D Overworld listing to 3D Concerts on Projects page

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6893c599b7c08332a490735f2b43995f