### PR TITLE
Refactor scene and mobile control components

### DIFF
--- a/src/components/UI/ActionButtons.jsx
+++ b/src/components/UI/ActionButtons.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const ActionButtons = ({
+  holdRun,
+  onRunDown,
+  onRunUp,
+  onInteract,
+  onJump,
+  onAttack,
+  onDodge
+}) => (
+  <>
+    <div className="flex gap-3">
+      <button
+        onTouchStart={onRunDown}
+        onTouchEnd={onRunUp}
+        onMouseDown={onRunDown}
+        onMouseUp={onRunUp}
+        className={`w-16 h-16 rounded-full border-2 ${holdRun ? 'bg-yellow-400 text-black border-yellow-300' : 'bg-black/60 text-yellow-300 border-yellow-500'} shadow-xl active:scale-95 transition-transform font-bold`}
+        aria-label="Run (hold)"
+      >
+        Run
+      </button>
+      <button
+        onTouchStart={onInteract}
+        onMouseDown={onInteract}
+        className="w-16 h-16 rounded-full border-2 bg-black/60 text-blue-300 border-blue-500 shadow-xl active:scale-95 transition-transform font-bold"
+        aria-label="Interact"
+      >
+        F
+      </button>
+    </div>
+    <div className="flex gap-3">
+      <button
+        onTouchStart={onJump}
+        onMouseDown={onJump}
+        className="w-16 h-16 rounded-full border-2 bg-black/60 text-green-300 border-green-500 shadow-xl active:scale-95 transition-transform font-bold"
+        aria-label="Jump"
+      >
+        ⤴︎
+      </button>
+      <button
+        onTouchStart={onAttack}
+        onMouseDown={onAttack}
+        className="w-20 h-20 rounded-full border-2 bg-black/70 text-red-300 border-red-500 shadow-2xl active:scale-95 transition-transform font-bold text-xl"
+        aria-label="Attack"
+      >
+        ⚔️
+      </button>
+      <button
+        onTouchStart={onDodge}
+        onMouseDown={onDodge}
+        className="w-16 h-16 rounded-full border-2 bg-black/60 text-purple-300 border-purple-500 shadow-xl active:scale-95 transition-transform font-bold"
+        aria-label="Dodge"
+      >
+        ⇲
+      </button>
+    </div>
+  </>
+);
+
+export default ActionButtons;

--- a/src/components/UI/MobileControls.jsx
+++ b/src/components/UI/MobileControls.jsx
@@ -1,84 +1,24 @@
-import { Fragment, jsxDEV } from "react/jsx-dev-runtime";
-import React, { useEffect, useRef, useState } from "react";
-import nipplejs from "nipplejs";
+import React, { useEffect, useRef, useState } from 'react';
+import { useJoystick } from '../../hooks/useJoystick.js';
+import ZoomControls from './ZoomControls.jsx';
+import ActionButtons from './ActionButtons.jsx';
+
 const clampPitch = (v) => Math.max(-0.9, Math.min(0.9, v));
-const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraPitchRef }) => {
-  const zoneRef = useRef(null);
-  const managerRef = useRef(null);
+
+export const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraPitchRef }) => {
+  const [visible, setVisible] = useState(true);
   const lookPadRef = useRef(null);
   const lookTargetRef = useRef({ yaw: 0, pitch: 0 });
   const lookRafRef = useRef(null);
-  const [visible, setVisible] = useState(true);
-  const smoothedRef = useRef({ force: 0, angle: { radian: 0 } });
-  const targetRef = useRef({ force: 0, angle: { radian: 0 } });
-  const rafRef = useRef(null);
-  const DEADZONE = 0.12;
-  const SMOOTHING = 0.18;
+  const zoneRef = useJoystick(joystickRef, visible);
+  const [holdRun, setHoldRun] = useState(false);
+
   const buzz = (ms = 15) => {
     try {
       window.navigator?.vibrate?.(ms);
-    } catch (_) {
-    }
+    } catch (_) {}
   };
-  const [holdRun, setHoldRun] = useState(false);
-  useEffect(() => {
-    if (!zoneRef.current) return;
-    const preventDefault = (e) => {
-      if (e.cancelable) e.preventDefault();
-    };
-    if (visible) {
-      zoneRef.current.addEventListener("touchmove", preventDefault, { passive: false });
-      zoneRef.current.addEventListener("touchstart", preventDefault, { passive: false });
-      zoneRef.current.addEventListener("touchend", preventDefault, { passive: false });
-    }
-    if (visible) {
-      const manager = nipplejs.create({
-        zone: zoneRef.current,
-        mode: "dynamic",
-        color: "rgba(255, 255, 255, 0.85)",
-        size: 130,
-        restJoystick: true,
-        multitouch: false,
-        maxNumberOfNipples: 1,
-        fadeTime: 100
-      });
-      managerRef.current = manager;
-      manager.on("start", () => {
-      });
-      manager.on("move", (_, data) => {
-        const rawForce = Math.max(0, data.force || 0);
-        const force = rawForce < DEADZONE ? 0 : Math.min(1, rawForce);
-        const rad = data.angle?.radian ?? 0;
-        targetRef.current = { force, angle: { radian: rad } };
-      });
-      manager.on("end", () => {
-        targetRef.current = { force: 0, angle: { radian: smoothedRef.current.angle.radian } };
-      });
-    }
-    const tick = () => {
-      const s = smoothedRef.current;
-      const t = targetRef.current;
-      s.force += (t.force - s.force) * SMOOTHING;
-      let delta = t.angle.radian - s.angle.radian;
-      while (delta > Math.PI) delta -= Math.PI * 2;
-      while (delta < -Math.PI) delta += Math.PI * 2;
-      s.angle.radian = s.angle.radian + delta * SMOOTHING;
-      joystickRef.current = { force: s.force, angle: { radian: s.angle.radian } };
-      rafRef.current = requestAnimationFrame(tick);
-    };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      if (managerRef.current) {
-        managerRef.current.destroy();
-        managerRef.current = null;
-      }
-      if (zoneRef.current) {
-        zoneRef.current.removeEventListener("touchmove", preventDefault);
-        zoneRef.current.removeEventListener("touchend", preventDefault);
-      }
-    };
-  }, [joystickRef, visible]);
+
   const pressKey = (code) => {
     if (!keysRef?.current) return;
     keysRef.current[code] = true;
@@ -93,6 +33,7 @@ const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraP
     if (clickFlag) keysRef.current[clickFlag] = true;
     setTimeout(() => releaseKey(code), 0);
   };
+
   const clampZoom = (z) => Math.max(0.2, Math.min(2.5, z));
   const handleZoomIn = () => {
     if (!zoomRef) return;
@@ -106,41 +47,41 @@ const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraP
   };
   const handleRunDown = () => {
     setHoldRun(true);
-    pressKey("ShiftLeft");
+    pressKey('ShiftLeft');
     buzz(8);
   };
   const handleRunUp = () => {
     setHoldRun(false);
-    releaseKey("ShiftLeft");
+    releaseKey('ShiftLeft');
   };
   const handleJump = () => {
-    clickKey("Space");
+    clickKey('Space');
     buzz(12);
   };
   const handleAttack = () => {
-    clickKey("MouseLeft", "MouseLeftClicked");
+    clickKey('MouseLeft', 'MouseLeftClicked');
     buzz(10);
   };
   const handleDodge = () => {
-    clickKey("ControlLeft");
+    clickKey('ControlLeft');
     buzz(10);
   };
   const handleInteract = () => {
-    clickKey("KeyF", "KeyFClicked");
+    clickKey('KeyF', 'KeyFClicked');
     buzz(8);
   };
+
   useEffect(() => {
     if (!lookPadRef.current) return;
     let active = false;
     let lastX = 0;
     let lastY = 0;
-    const BASE_SENS_X = 8e-3;
-    const BASE_SENS_Y = 0.01;
+    const BASE_SENS_X = 0.008;
+    const BASE_SENS_Y = 0.010;
     const EASE = 0.22;
-    const MOMENTUM = 0;
     const normalizeAngle = (a) => {
       const twoPI = Math.PI * 2;
-      a = (a % twoPI + twoPI) % twoPI;
+      a = ((a % twoPI) + twoPI) % twoPI;
       if (a > Math.PI) a -= twoPI;
       return a;
     };
@@ -162,14 +103,14 @@ const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraP
     lookRafRef.current = requestAnimationFrame(lookTick);
     const onStart = (e) => {
       active = true;
-      const t = e.touches && e.touches[0] || e;
+      const t = (e.touches && e.touches[0]) || e;
       lastX = t.clientX;
       lastY = t.clientY;
       if (e.cancelable) e.preventDefault();
     };
     const onMove = (e) => {
       if (!active) return;
-      const t = e.touches && e.touches[0] || e;
+      const t = (e.touches && e.touches[0]) || e;
       const dx = t.clientX - lastX;
       const dy = t.clientY - lastY;
       lastX = t.clientX;
@@ -194,257 +135,80 @@ const MobileControls = ({ joystickRef, keysRef, zoomRef, cameraOrbitRef, cameraP
       active = false;
     };
     const el = lookPadRef.current;
-    el.addEventListener("touchstart", onStart, { passive: false });
-    el.addEventListener("touchmove", onMove, { passive: false });
-    el.addEventListener("touchend", onEnd, { passive: false });
-    el.addEventListener("touchcancel", onEnd, { passive: false });
-    el.addEventListener("mousedown", onStart);
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onEnd);
+    el.addEventListener('touchstart', onStart, { passive: false });
+    el.addEventListener('touchmove', onMove, { passive: false });
+    el.addEventListener('touchend', onEnd, { passive: false });
+    el.addEventListener('touchcancel', onEnd, { passive: false });
+    el.addEventListener('mousedown', onStart);
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onEnd);
     return () => {
-      el.removeEventListener("touchstart", onStart);
-      el.removeEventListener("touchmove", onMove);
-      el.removeEventListener("touchend", onEnd);
-      el.removeEventListener("touchcancel", onEnd);
-      el.removeEventListener("mousedown", onStart);
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onEnd);
+      el.removeEventListener('touchstart', onStart);
+      el.removeEventListener('touchmove', onMove);
+      el.removeEventListener('touchend', onEnd);
+      el.removeEventListener('touchcancel', onEnd);
+      el.removeEventListener('mousedown', onStart);
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onEnd);
       if (lookRafRef.current) cancelAnimationFrame(lookRafRef.current);
     };
   }, [cameraOrbitRef, cameraPitchRef, visible, zoomRef]);
-  return /* @__PURE__ */ jsxDEV(Fragment, { children: [
-    /* @__PURE__ */ jsxDEV("div", { className: "absolute top-4 right-4 z-30", children: /* @__PURE__ */ jsxDEV(
-      "button",
-      {
-        onTouchStart: () => setVisible((v) => !v),
-        onMouseDown: () => setVisible((v) => !v),
-        className: `px-3 py-2 rounded-full border-2 shadow-lg text-sm ${visible ? "bg-black/70 text-white border-gray-400" : "bg-yellow-500 text-black border-yellow-300"}`,
-        "aria-label": "Toggle mobile controls",
-        title: "Toggle controls",
-        children: visible ? "Hide Controls" : "Show Controls"
-      },
-      void 0,
-      false,
-      {
-        fileName: "<stdin>",
-        lineNumber: 301,
-        columnNumber: 17
-      }
-    ) }, void 0, false, {
-      fileName: "<stdin>",
-      lineNumber: 300,
-      columnNumber: 13
-    }),
-    visible && /* @__PURE__ */ jsxDEV(
-      "div",
-      {
-        ref: zoneRef,
-        className: "absolute bottom-0 left-0 w-1/2 h-full z-20",
-        style: { touchAction: "none" }
-      },
-      void 0,
-      false,
-      {
-        fileName: "<stdin>",
-        lineNumber: 314,
-        columnNumber: 17
-      }
-    ),
-    visible ? /* @__PURE__ */ jsxDEV("div", { className: "absolute bottom-6 right-6 z-20 flex flex-col gap-4 items-end select-none", children: [
-      /* @__PURE__ */ jsxDEV("div", { className: "flex flex-col items-center gap-2 mb-2", children: [
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleZoomIn,
-            onMouseDown: handleZoomIn,
-            className: "w-12 h-12 rounded-full border-2 bg-black/60 text-white border-gray-400 shadow-xl active:scale-95 transition-transform font-bold text-xl",
-            "aria-label": "Zoom In",
-            title: "Zoom In",
-            children: "\uFF0B"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 326,
-            columnNumber: 25
-          }
-        ),
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleZoomOut,
-            onMouseDown: handleZoomOut,
-            className: "w-12 h-12 rounded-full border-2 bg-black/60 text-white border-gray-400 shadow-xl active:scale-95 transition-transform font-bold text-xl",
-            "aria-label": "Zoom Out",
-            title: "Zoom Out",
-            children: "\uFF0D"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 335,
-            columnNumber: 25
-          }
-        )
-      ] }, void 0, true, {
-        fileName: "<stdin>",
-        lineNumber: 325,
-        columnNumber: 21
-      }),
-      /* @__PURE__ */ jsxDEV(
-        "div",
-        {
-          ref: lookPadRef,
-          className: "w-20 h-20 rounded-full border-2 border-amber-400 bg-black/50 shadow-2xl flex items-center justify-center text-amber-300 font-bold select-none",
-          style: { touchAction: "none" },
-          "aria-label": "Camera look pad (drag to rotate camera)",
-          title: "Look (drag to rotate camera)",
-          children: "Cam"
-        },
-        void 0,
-        false,
-        {
-          fileName: "<stdin>",
-          lineNumber: 347,
-          columnNumber: 21
-        }
-      ),
-      /* @__PURE__ */ jsxDEV("div", { className: "flex gap-3", children: [
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleRunDown,
-            onTouchEnd: handleRunUp,
-            onMouseDown: handleRunDown,
-            onMouseUp: handleRunUp,
-            className: `w-16 h-16 rounded-full border-2 ${holdRun ? "bg-yellow-400 text-black border-yellow-300" : "bg-black/60 text-yellow-300 border-yellow-500"} shadow-xl active:scale-95 transition-transform font-bold`,
-            "aria-label": "Run (hold)",
-            children: "Run"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 359,
-            columnNumber: 25
-          }
-        ),
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleInteract,
-            onMouseDown: handleInteract,
-            className: "w-16 h-16 rounded-full border-2 bg-black/60 text-blue-300 border-blue-500 shadow-xl active:scale-95 transition-transform font-bold",
-            "aria-label": "Interact",
-            children: "F"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 369,
-            columnNumber: 25
-          }
-        )
-      ] }, void 0, true, {
-        fileName: "<stdin>",
-        lineNumber: 358,
-        columnNumber: 21
-      }),
-      /* @__PURE__ */ jsxDEV("div", { className: "flex gap-3", children: [
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleJump,
-            onMouseDown: handleJump,
-            className: "w-16 h-16 rounded-full border-2 bg-black/60 text-green-300 border-green-500 shadow-xl active:scale-95 transition-transform font-bold",
-            "aria-label": "Jump",
-            children: "\u2934\uFE0E"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 381,
-            columnNumber: 25
-          }
-        ),
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleAttack,
-            onMouseDown: handleAttack,
-            className: "w-20 h-20 rounded-full border-2 bg-black/70 text-red-300 border-red-500 shadow-2xl active:scale-95 transition-transform font-bold text-xl",
-            "aria-label": "Attack",
-            children: "\u2694\uFE0F"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 389,
-            columnNumber: 25
-          }
-        ),
-        /* @__PURE__ */ jsxDEV(
-          "button",
-          {
-            onTouchStart: handleDodge,
-            onMouseDown: handleDodge,
-            className: "w-16 h-16 rounded-full border-2 bg-black/60 text-purple-300 border-purple-500 shadow-xl active:scale-95 transition-transform font-bold",
-            "aria-label": "Dodge",
-            children: "\u21F2"
-          },
-          void 0,
-          false,
-          {
-            fileName: "<stdin>",
-            lineNumber: 397,
-            columnNumber: 25
-          }
-        )
-      ] }, void 0, true, {
-        fileName: "<stdin>",
-        lineNumber: 380,
-        columnNumber: 21
-      })
-    ] }, void 0, true, {
-      fileName: "<stdin>",
-      lineNumber: 323,
-      columnNumber: 17
-    }) : (
-      // Compact "Show Controls" button when hidden
-      /* @__PURE__ */ jsxDEV("div", { className: "absolute bottom-6 right-6 z-20", children: /* @__PURE__ */ jsxDEV(
-        "button",
-        {
-          onTouchStart: () => setVisible(true),
-          onMouseDown: () => setVisible(true),
-          className: "px-3 py-2 rounded-full bg-black/60 text-white border border-gray-400 text-sm shadow-lg",
-          "aria-label": "Show mobile controls",
-          title: "Show controls",
-          children: "Controls"
-        },
-        void 0,
-        false,
-        {
-          fileName: "<stdin>",
-          lineNumber: 410,
-          columnNumber: 21
-        }
-      ) }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 409,
-        columnNumber: 17
-      })
-    )
-  ] }, void 0, true, {
-    fileName: "<stdin>",
-    lineNumber: 298,
-    columnNumber: 9
-  });
-};
-export {
-  MobileControls
+
+  return (
+    <>
+      <div className="absolute top-4 right-4 z-30">
+        <button
+          onTouchStart={() => setVisible((v) => !v)}
+          onMouseDown={() => setVisible((v) => !v)}
+          className={`px-3 py-2 rounded-full border-2 shadow-lg text-sm ${visible ? 'bg-black/70 text-white border-gray-400' : 'bg-yellow-500 text-black border-yellow-300'}`}
+          aria-label="Toggle mobile controls"
+          title="Toggle controls"
+        >
+          {visible ? 'Hide Controls' : 'Show Controls'}
+        </button>
+      </div>
+      {visible && (
+        <div
+          ref={zoneRef}
+          className="absolute bottom-0 left-0 w-1/2 h-full z-20"
+          style={{ touchAction: 'none' }}
+        />
+      )}
+      {visible ? (
+        <div className="absolute bottom-6 right-6 z-20 flex flex-col gap-4 items-end select-none">
+          <ZoomControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} />
+          <div
+            ref={lookPadRef}
+            className="w-20 h-20 rounded-full border-2 border-amber-400 bg-black/50 shadow-2xl flex items-center justify-center text-amber-300 font-bold select-none"
+            style={{ touchAction: 'none' }}
+            aria-label="Camera look pad (drag to rotate camera)"
+            title="Look (drag to rotate camera)"
+          >
+            Cam
+          </div>
+          <ActionButtons
+            holdRun={holdRun}
+            onRunDown={handleRunDown}
+            onRunUp={handleRunUp}
+            onInteract={handleInteract}
+            onJump={handleJump}
+            onAttack={handleAttack}
+            onDodge={handleDodge}
+          />
+        </div>
+      ) : (
+        <div className="absolute bottom-6 right-6 z-20">
+          <button
+            onTouchStart={() => setVisible(true)}
+            onMouseDown={() => setVisible(true)}
+            className="px-3 py-2 rounded-full bg-black/60 text-white border border-gray-400 text-sm shadow-lg"
+            aria-label="Show mobile controls"
+            title="Show controls"
+          >
+            Controls
+          </button>
+        </div>
+      )}
+    </>
+  );
 };

--- a/src/components/UI/ZoomControls.jsx
+++ b/src/components/UI/ZoomControls.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const ZoomControls = ({ onZoomIn, onZoomOut }) => (
+  <div className="flex flex-col items-center gap-2 mb-2">
+    <button
+      onTouchStart={onZoomIn}
+      onMouseDown={onZoomIn}
+      className="w-12 h-12 rounded-full border-2 bg-black/60 text-white border-gray-400 shadow-xl active:scale-95 transition-transform font-bold text-xl"
+      aria-label="Zoom In"
+      title="Zoom In"
+    >
+      ＋
+    </button>
+    <button
+      onTouchStart={onZoomOut}
+      onMouseDown={onZoomOut}
+      className="w-12 h-12 rounded-full border-2 bg-black/60 text-white border-gray-400 shadow-xl active:scale-95 transition-transform font-bold text-xl"
+      aria-label="Zoom Out"
+      title="Zoom Out"
+    >
+      －
+    </button>
+  </div>
+);
+
+export default ZoomControls;

--- a/src/hooks/sceneLifecycle.js
+++ b/src/hooks/sceneLifecycle.js
@@ -1,0 +1,131 @@
+import { initScene } from '../scene/initScene.js';
+import { createPlayer } from '../game/player/index.js';
+
+export function initThreeScene({
+  mountRef,
+  settings,
+  onReadyRef,
+  sceneRef,
+  rendererRef,
+  cameraRef,
+  lightRef,
+  groundContainerRef,
+  gridHelperRef,
+  gridLabelsGroupRef,
+  gridLabelsUpdateRef,
+  playerRef,
+  objectTooltipsGroupRef,
+  objectTooltipsUpdateRef,
+  interactPromptRef
+}) {
+  if (!mountRef.current) return;
+
+  const {
+    scene,
+    renderer,
+    camera,
+    light,
+    groundContainer,
+    gridHelper,
+    gridLabelsGroup,
+    gridLabelsUpdate,
+    player,
+    objectTooltipsGroup,
+    updateObjectTooltips
+  } = initScene({
+    mountEl: mountRef.current,
+    settings: {
+      antialiasing: settings.antialiasing,
+      shadows: settings.shadows,
+      shadowQuality: settings.shadowQuality,
+      grid: settings.grid
+    },
+    createPlayer,
+    onReady: () => {
+      try {
+        onReadyRef.current && onReadyRef.current();
+      } catch (_) {}
+    }
+  });
+
+  sceneRef.current = scene;
+  rendererRef.current = renderer;
+  cameraRef.current = camera;
+  lightRef.current = light;
+  groundContainerRef.current = groundContainer;
+  gridHelperRef.current = gridHelper;
+  gridLabelsGroupRef.current = gridLabelsGroup;
+  gridLabelsUpdateRef.current = gridLabelsUpdate;
+  playerRef.current = player;
+  objectTooltipsGroupRef.current = objectTooltipsGroup;
+  objectTooltipsUpdateRef.current = updateObjectTooltips;
+
+  const prompt = document.createElement('div');
+  prompt.style.position = 'absolute';
+  prompt.style.left = '50%';
+  prompt.style.bottom = '8%';
+  prompt.style.transform = 'translateX(-50%)';
+  prompt.style.padding = '8px 12px';
+  prompt.style.background = 'rgba(0,0,0,0.7)';
+  prompt.style.border = '2px solid rgba(234, 179, 8, 0.9)';
+  prompt.style.color = '#fff';
+  prompt.style.fontFamily = 'system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif';
+  prompt.style.borderRadius = '8px';
+  prompt.style.pointerEvents = 'none';
+  prompt.style.display = 'none';
+  prompt.style.zIndex = '25';
+  prompt.id = 'interaction-prompt';
+  mountRef.current.appendChild(prompt);
+  interactPromptRef.current = prompt;
+}
+
+export function cleanupThreeScene({
+  mountRef,
+  rendererRef,
+  sceneRef,
+  animationStopRef,
+  interactPromptRef,
+  groundContainerRef,
+  gridLabelsGroupRef,
+  gridLabelsArrayRef,
+  visibleLabelsRef,
+  randomObjectsRef,
+  objectGridRef
+}) {
+  if (animationStopRef.current) {
+    animationStopRef.current();
+    animationStopRef.current = null;
+  }
+  if (
+    interactPromptRef.current &&
+    mountRef.current &&
+    mountRef.current.contains(interactPromptRef.current)
+  ) {
+    mountRef.current.removeChild(interactPromptRef.current);
+  }
+  interactPromptRef.current = null;
+
+  if (rendererRef.current) {
+    rendererRef.current.dispose();
+    if (
+      mountRef.current &&
+      rendererRef.current.domElement &&
+      mountRef.current.contains(rendererRef.current.domElement)
+    ) {
+      mountRef.current.removeChild(rendererRef.current.domElement);
+    }
+    rendererRef.current = null;
+  }
+  if (sceneRef.current) {
+    while (sceneRef.current.children.length > 0) {
+      sceneRef.current.remove(sceneRef.current.children[0]);
+    }
+    sceneRef.current = null;
+  }
+  groundContainerRef.current = null;
+  gridLabelsGroupRef.current = null;
+  gridLabelsArrayRef.current = null;
+  if (visibleLabelsRef.current) visibleLabelsRef.current.clear();
+  randomObjectsRef.current = [];
+  if (objectGridRef.current) objectGridRef.current.clear();
+}

--- a/src/hooks/useJoystick.js
+++ b/src/hooks/useJoystick.js
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import nipplejs from 'nipplejs';
+
+const DEADZONE = 0.12;
+const SMOOTHING = 0.18;
+
+export function useJoystick(joystickRef, visible) {
+  const zoneRef = useRef(null);
+  const managerRef = useRef(null);
+  const smoothedRef = useRef({ force: 0, angle: { radian: 0 } });
+  const targetRef = useRef({ force: 0, angle: { radian: 0 } });
+  const rafRef = useRef(null);
+
+  useEffect(() => {
+    if (!zoneRef.current) return;
+    const preventDefault = (e) => {
+      if (e.cancelable) e.preventDefault();
+    };
+    if (visible) {
+      zoneRef.current.addEventListener('touchmove', preventDefault, { passive: false });
+      zoneRef.current.addEventListener('touchstart', preventDefault, { passive: false });
+      zoneRef.current.addEventListener('touchend', preventDefault, { passive: false });
+    }
+    if (visible) {
+      const manager = nipplejs.create({
+        zone: zoneRef.current,
+        mode: 'dynamic',
+        color: 'rgba(255, 255, 255, 0.85)',
+        size: 130,
+        restJoystick: true,
+        multitouch: false,
+        maxNumberOfNipples: 1,
+        fadeTime: 100,
+      });
+      managerRef.current = manager;
+      manager.on('start', () => {});
+      manager.on('move', (_, data) => {
+        const rawForce = Math.max(0, data.force || 0);
+        const force = rawForce < DEADZONE ? 0 : Math.min(1, rawForce);
+        const rad = data.angle?.radian ?? 0;
+        targetRef.current = { force, angle: { radian: rad } };
+      });
+      manager.on('end', () => {
+        targetRef.current = { force: 0, angle: { radian: smoothedRef.current.angle.radian } };
+      });
+    }
+    const tick = () => {
+      const s = smoothedRef.current;
+      const t = targetRef.current;
+      s.force += (t.force - s.force) * SMOOTHING;
+      let delta = t.angle.radian - s.angle.radian;
+      while (delta > Math.PI) delta -= Math.PI * 2;
+      while (delta < -Math.PI) delta += Math.PI * 2;
+      s.angle.radian = s.angle.radian + delta * SMOOTHING;
+      if (joystickRef) {
+        joystickRef.current = { force: s.force, angle: { radian: s.angle.radian } };
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (managerRef.current) {
+        managerRef.current.destroy();
+        managerRef.current = null;
+      }
+      if (zoneRef.current) {
+        zoneRef.current.removeEventListener('touchmove', preventDefault);
+        zoneRef.current.removeEventListener('touchstart', preventDefault);
+        zoneRef.current.removeEventListener('touchend', preventDefault);
+      }
+    };
+  }, [joystickRef, visible]);
+
+  return zoneRef;
+}


### PR DESCRIPTION
## Summary
- factor scene init/cleanup into separate helpers
- split mobile controls into smaller components and hooks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a07ad68848332929b398279c0f34f