### PR TITLE
Make movement relative to camera orientation

### DIFF
--- a/src/game/player/index.js
+++ b/src/game/player/index.js
@@ -97,11 +97,12 @@ export function updatePlayer(player, keys, camera, light, throttledSetPlayerPosi
         player.userData.model.visible = !fpv;
     }
 
-    // First, determine camera yaw as it's needed for movement controls
+    // First, determine camera yaw/pitch for movement controls
     const yaw = (cameraOrbitRef && typeof cameraOrbitRef.current === 'number') ? cameraOrbitRef.current : 0;
-    
-    // Pass objectGrid and camera yaw to movement for camera-relative controls
-    updatePlayerMovement(player, keys, joystick, delta, objectGrid, yaw);
+    const pitch = (cameraPitchRef && typeof cameraPitchRef.current === 'number') ? cameraPitchRef.current : 0;
+
+    // Pass objectGrid and camera orientation to movement for camera-relative controls
+    updatePlayerMovement(player, keys, joystick, delta, objectGrid, yaw, pitch);
     
     // Update animation mixer
     if (player.userData.mixer) {


### PR DESCRIPTION
## Summary
- Rotate player movement based on camera yaw and pitch
- Pass camera orientation into movement handling for unified first- and third-person controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ef0f7088332adea92917f4ff7de