### PR TITLE
Improve environmental collision accuracy

### DIFF
--- a/src/game/objects/placements/ichiraku.js
+++ b/src/game/objects/placements/ichiraku.js
@@ -9,12 +9,14 @@ export function placeIchiraku(scene, objectGrid, worldSize, settings, label = 'L
     const pos = posForCell(i, j, worldSize);
     pos.y = 0;
 
-    const { group, colliderProxy } = createIchiraku({ position: pos, settings });
+    const { group, colliderProxies } = createIchiraku({ position: pos, settings });
     scene.add(group);
 
-    if (colliderProxy) {
-      scene.add(colliderProxy);
-      objectGrid.add(colliderProxy);
+    if (Array.isArray(colliderProxies)) {
+      colliderProxies.forEach(proxy => {
+        scene.add(proxy);
+        objectGrid.add(proxy);
+      });
     }
 
     return group;


### PR DESCRIPTION
## Summary
- Generate oriented bounding box colliders for all procedurally placed Konoha buildings
- Replace Ichiraku shop's single AABB with multiple detailed OBB proxies
- Update placement logic to register new collider proxies with the world grid

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d3eda2c38833285c8f95af8dbdd0c