### PR TITLE
Add metadata for Konoha districts

### DIFF
--- a/map/user-defaults-data.js
+++ b/map/user-defaults-data.js
@@ -58,304 +58,462 @@ export const DEFAULT_MODEL = {
     },
     "district-2": {
       "id": "district-2",
-      "name": "",
-      "desc": "",
+      "name": "Uchiha District",
+      "desc": "Former police-run clan quarter. Includes Nakano Shrine, training courts, and surviving residences; treat as quiet/solemn post-massacre.",
+      "tags": [
+        "clan",
+        "historic",
+        "security"
+      ],
       "points": [
         [39.25, 33.54], [52.18, 38.78], [51.87, 30.1], [50.31, 29.93], [50.31, 25.18], [51.71, 24.69], [52.02, 23.38], [49.84, 23.38]
       ]
     },
     "district-3": {
       "id": "district-3",
-      "name": "",
-      "desc": "",
+      "name": "Hokage Administrative Ward",
+      "desc": "Hokage Tower, mission assignment desk, council chamber, and civil records counters. Administrative heart of the village.",
+      "tags": [
+        "administration",
+        "civic"
+      ],
       "points": [
         [52.75, 23.25], [53.81, 22.69], [55.5, 24.36], [54.87, 25.47], [56.24, 28.14], [57.72, 26.36], [59.73, 28.03], [60.68, 31.26], [61.85, 32.93], [61.21, 33.82], [61.42, 35.26], [53.07, 39.15]
       ]
     },
     "district-4": {
       "id": "district-4",
-      "name": "",
-      "desc": "",
+      "name": "Ninja Academy & Grounds",
+      "desc": "Primary shinobi school with classrooms, track, target ranges, and practice yards.",
+      "tags": [
+        "education",
+        "training"
+      ],
       "points": [
         [53.38, 39.71], [65.34, 52.06], [62.9, 36.04]
       ]
     },
     "district-5": {
       "id": "district-5",
-      "name": "",
-      "desc": "",
+      "name": "Chūnin Exam Stadium & Arena Ward",
+      "desc": "Tournament arena with concourses, warm‑up rings, and crowd logistics; doubles as disaster drill venue.",
+      "tags": [
+        "training",
+        "events",
+        "infrastructure"
+      ],
       "points": [
         [63.54, 35.82], [65.13, 45.83], [73.27, 43.94], [71.68, 40.04], [72.21, 39.15], [68.83, 36.48], [67.77, 37.37], [64.7, 35.26]
       ]
     },
     "district-6": {
       "id": "district-6",
-      "name": "",
-      "desc": "",
+      "name": "Konoha Hospital & Medical Corps",
+      "desc": "Emergency wards, chakra treatment floors, surgical theatres, blood bank, and rooftop messenger posts.",
+      "tags": [
+        "medical"
+      ],
       "points": [
         [65.23, 46.61], [66.08, 52.28], [71.37, 52.28], [72.21, 45.05]
       ]
     },
     "district-7": {
       "id": "district-7",
-      "name": "",
-      "desc": "",
+      "name": "T&I + Intelligence Division",
+      "desc": "Interrogation wing, analysis rooms, evidence vaults. Restricted access; pairs with mission intel.",
+      "tags": [
+        "security",
+        "administration"
+      ],
       "points": [
         [74.01, 44.83], [73.06, 44.83], [72.21, 52.17], [87.23, 52.39], [82.58, 48.72], [76.87, 49.5]
       ]
     },
     "district-8": {
       "id": "district-8",
-      "name": "",
-      "desc": "",
+      "name": "ANBU Headquarters",
+      "desc": "Covert ops briefing bunker, armory, rooftop ingress. Nondescript exterior; high security.",
+      "tags": [
+        "security"
+      ],
       "points": [
         [52.96, 40.27], [53.17, 47.16], [55.29, 47.16], [55.5, 50.28], [62.48, 50.28]
       ]
     },
     "district-9": {
       "id": "district-9",
-      "name": "",
-      "desc": "",
+      "name": "Foundation (Root) Sublevels",
+      "desc": "Decommissioned underground training and storage levels once used by Root. Marked restricted/defunct.",
+      "tags": [
+        "security",
+        "historic",
+        "restricted"
+      ],
       "points": [
         [64.91, 52.73], [53.91, 52.5], [53.38, 51.61], [53.38, 50.06], [55.29, 50.06], [55.39, 50.61], [63.12, 50.5]
       ]
     },
     "district-10": {
       "id": "district-10",
-      "name": "",
-      "desc": "",
+      "name": "Military Police Force HQ",
+      "desc": "Intake desk, holding cells, and archives. Historic ties to Uchiha; current police garrison.",
+      "tags": [
+        "security",
+        "administration"
+      ],
       "points": [
         [53.81, 53.39], [58.78, 61.74], [64.91, 53.28]
       ]
     },
     "district-11": {
       "id": "district-11",
-      "name": "",
-      "desc": "",
+      "name": "Library & Archives (Civil)",
+      "desc": "Public stacks, reading rooms, and map/archive vault distinct from ninja intel records.",
+      "tags": [
+        "civic",
+        "education"
+      ],
       "points": [
         [40.9, 52.61], [48.41, 52.5], [48.52, 51.84], [50, 51.95], [50.53, 50.39], [52.33, 49.83], [52.33, 40.71]
       ]
     },
     "district-12": {
       "id": "district-12",
-      "name": "",
-      "desc": "",
+      "name": "Medical Research Institute",
+      "desc": "Labs for antidotes, poisons, and medical ninjutsu; attached herbarium and cold rooms.",
+      "tags": [
+        "medical",
+        "research"
+      ],
       "points": [
         [39.11, 36.71], [41.01, 36.6], [40.69, 35.04], [51.27, 39.71], [46.09, 46.27], [39.85, 45.16]
       ]
     },
     "district-13": {
       "id": "district-13",
-      "name": "",
-      "desc": "",
+      "name": "Scientific Ninja Tools Lab",
+      "desc": "R&D bays for ninja tech prototypes with fenced test yard and secure storage.",
+      "tags": [
+        "research",
+        "science",
+        "security"
+      ],
       "points": [
         [41.12, 31.03], [39, 29.7], [37.2, 31.48], [37.52, 32.81], [31.49, 30.14], [32.34, 28.7], [34.03, 29.59], [36.04, 27.59], [34.77, 26.14], [36.88, 24.03], [44.29, 27.81]
       ]
     },
     "district-14": {
       "id": "district-14",
-      "name": "",
-      "desc": "",
+      "name": "Restaurant Row (Ichiraku / Yakiniku Q)",
+      "desc": "Food district anchored by Ichiraku Ramen and Yakiniku Q; dessert stalls and tea houses nearby.",
+      "tags": [
+        "commerce",
+        "food",
+        "landmark"
+      ],
       "points": [
         [28.53, 43.6], [37.94, 34.71], [38.89, 45.05]
       ]
     },
     "district-15": {
       "id": "district-15",
-      "name": "",
-      "desc": "",
+      "name": "Central Bazaar (Market II)",
+      "desc": "Crowded market streets with tool vendors, produce, and festival booths.",
+      "tags": [
+        "commerce",
+        "market"
+      ],
       "points": [
         [22.08, 34.82], [32.65, 38.6], [37.84, 33.7], [25.14, 28.59]
       ]
     },
     "district-16": {
       "id": "district-16",
-      "name": "",
-      "desc": "",
+      "name": "Fire Plaza & Market I",
+      "desc": "Civic festival square honoring the Land of Fire; parade route and seasonal stalls.",
+      "tags": [
+        "commerce",
+        "civic",
+        "events"
+      ],
       "points": [
         [21.76, 35.71], [19.33, 42.27], [27.68, 43.49], [30.33, 40.71], [28, 39.49], [28.11, 38.04]
       ]
     },
     "district-17": {
       "id": "district-17",
-      "name": "",
-      "desc": "",
+      "name": "Craftsmen & Weaponers’ Street",
+      "desc": "Smithies, armorers, repair shops, and general shinobi-tools retail.",
+      "tags": [
+        "commerce",
+        "industry"
+      ],
       "points": [
         [19.22, 43.27], [18.37, 51.95], [26.84, 44.27]
       ]
     },
     "district-18": {
       "id": "district-18",
-      "name": "",
-      "desc": "",
+      "name": "Inn & Hot Springs Quarter",
+      "desc": "Ryokan, bathhouses, tea gardens; best sited near water feed and outer road.",
+      "tags": [
+        "commerce",
+        "leisure",
+        "hospitality"
+      ],
       "points": [
         [19.22, 52.5], [28.11, 44.49], [32.97, 44.94], [31.38, 52.5]
       ]
     },
     "district-19": {
       "id": "district-19",
-      "name": "",
-      "desc": "",
+      "name": "Artisan Row (Calligraphy–Textiles–Ceramics)",
+      "desc": "Studios, kilns, dye works, and paper/calligraphy ateliers with service alleys.",
+      "tags": [
+        "commerce",
+        "arts"
+      ],
       "points": [
         [33.82, 45.16], [32.65, 52.39], [39.53, 52.61], [39.32, 48.16], [37.52, 47.83], [37.41, 45.72]
       ]
     },
     "district-20": {
       "id": "district-20",
-      "name": "",
-      "desc": "",
+      "name": "Jōnin Residential Quarter",
+      "desc": "Low-density homes with private dojos, messenger perches, and secure courtyards.",
+      "tags": [
+        "residential"
+      ],
       "points": [
         [39.63, 45.94], [40.16, 51.84], [45.35, 46.83]
       ]
     },
     "district-21": {
       "id": "district-21",
-      "name": "",
-      "desc": "",
+      "name": "Chūnin/Genin Housing",
+      "desc": "Mid-density housing blocks with shared yards and small practice nooks.",
+      "tags": [
+        "residential"
+      ],
       "points": [
         [19.11, 53.28], [21.55, 53.06], [21.76, 54.84], [23.77, 54.73], [23.87, 53.17], [31.17, 53.28], [26.1, 60.07]
       ]
     },
     "district-22": {
       "id": "district-22",
-      "name": "",
-      "desc": "",
+      "name": "Civilian North Ward",
+      "desc": "Civilian homes, corner shops, and a small elementary school; quiet streets.",
+      "tags": [
+        "residential",
+        "civic"
+      ],
       "points": [
         [18.59, 54.28], [20.91, 64.4], [25.25, 60.96]
       ]
     },
     "district-23": {
       "id": "district-23",
-      "name": "",
-      "desc": "",
+      "name": "Civilian East Ward",
+      "desc": "Civilian neighborhood with pocket parks and local services.",
+      "tags": [
+        "residential",
+        "civic"
+      ],
       "points": [
         [26.62, 60.62], [31.38, 65.18], [34.03, 60.96], [28.95, 57.84]
       ]
     },
     "district-24": {
       "id": "district-24",
-      "name": "",
-      "desc": "",
+      "name": "Civilian South Ward",
+      "desc": "Civilian neighborhood near southern arterials; mixed small commerce.",
+      "tags": [
+        "residential",
+        "civic"
+      ],
       "points": [
         [29.9, 56.95], [34.24, 59.84], [39, 53.28], [32.44, 53.5]
       ]
     },
     "district-25": {
       "id": "district-25",
-      "name": "",
-      "desc": "",
+      "name": "Civilian West Ward",
+      "desc": "Civilian neighborhood close to forest edge; community garden plots.",
+      "tags": [
+        "residential",
+        "civic"
+      ],
       "points": [
         [39.85, 53.73], [42.28, 57.51], [39.21, 61.07], [36.78, 61.62], [35.4, 60.73]
       ]
     },
     "district-26": {
       "id": "district-26",
-      "name": "",
-      "desc": "",
+      "name": "Barrier Team & Sensor Corps HQ",
+      "desc": "Barrier control hall, sensor dojo, and roof pylons for village-wide seals.",
+      "tags": [
+        "security",
+        "research"
+      ],
       "points": [
         [34.66, 61.51], [35.93, 62.18], [34.56, 65.07], [34.56, 67.85], [34.56, 68.41]
       ]
     },
     "district-27": {
       "id": "district-27",
-      "name": "",
-      "desc": "",
+      "name": "Orphanage & Relief House",
+      "desc": "Dormitories, clinic, storerooms; quiet street frontage with guarded play yard.",
+      "tags": [
+        "civic",
+        "medical",
+        "welfare"
+      ],
       "points": [
         [40.9, 53.5], [43.23, 57.17], [50.74, 53.39]
       ]
     },
     "district-28": {
       "id": "district-28",
-      "name": "",
-      "desc": "",
+      "name": "Training Grounds District (3/7/24 Cluster)",
+      "desc": "Riverside posts and shaded spar fields used by multiple teams (incl. Team 7 sites).",
+      "tags": [
+        "training",
+        "park"
+      ],
       "points": [
         [41.96, 59.73], [43.12, 58.06], [51.27, 54.39], [52.54, 55.06], [53.17, 62.96], [52.43, 62.63], [51.9, 61.4], [50, 60.96], [49.26, 59.96], [44.92, 58.95]
       ]
     },
     "district-29": {
       "id": "district-29",
-      "name": "",
-      "desc": "",
+      "name": "Forest-of-Death Gate Annex",
+      "desc": "Permit office, medical checkpoint, and supply sheds controlling access to Training Ground 44.",
+      "tags": [
+        "security",
+        "training",
+        "restricted"
+      ],
       "points": [
         [53.28, 54.73], [53.7, 62.85], [58.36, 63.96], [58.14, 62.07]
       ]
     },
     "district-30": {
       "id": "district-30",
-      "name": "",
-      "desc": "",
+      "name": "Waterworks & Canal Bridges",
+      "desc": "Pump houses, sluice controls, and bridge depots managing village waterways.",
+      "tags": [
+        "infrastructure"
+      ],
       "points": [
         [37.84, 71.75], [45.35, 79.09], [52.01, 72.41]
       ]
     },
     "district-31": {
       "id": "district-31",
-      "name": "",
-      "desc": "",
+      "name": "Storage & Armory Depots",
+      "desc": "Sealed arsenals and ration warehouses with messenger-hawk lofts.",
+      "tags": [
+        "infrastructure",
+        "security"
+      ],
       "points": [
         [46.3, 80.09], [53.17, 86.76], [53.17, 83.76], [51.59, 83.54], [51.48, 81.31], [52.86, 81.09], [52.86, 72.75]
       ]
     },
     "district-32": {
       "id": "district-32",
-      "name": "",
-      "desc": "",
+      "name": "Gate Garrison (North)",
+      "desc": "Inspection offices, barracks, stables, and courier post at the north gate.",
+      "tags": [
+        "security",
+        "infrastructure"
+      ],
       "points": [
         [53.81, 72.53], [54.02, 86.76], [61.74, 78.53], [60.26, 72.53]
       ]
     },
     "district-33": {
       "id": "district-33",
-      "name": "",
-      "desc": "",
+      "name": "Gate Garrison (East)",
+      "desc": "Inspection offices, barracks, stables, and courier post at the east gate.",
+      "tags": [
+        "security",
+        "infrastructure"
+      ],
       "points": [
         [61.21, 71.97], [62.8, 78.09], [65.97, 75.31], [64.38, 75.53], [63.22, 74.75], [63.43, 73.41], [64.7, 72.86], [66.5, 71.64]
       ]
     },
     "district-34": {
       "id": "district-34",
-      "name": "",
-      "desc": "",
+      "name": "Gate Garrison (South)",
+      "desc": "Inspection offices, barracks, stables, and courier post at the south gate.",
+      "tags": [
+        "security",
+        "infrastructure"
+      ],
       "points": [
         [54.23, 71.52], [66.61, 70.63], [67.88, 68.97], [64.49, 64.74], [59.2, 66.41]
       ]
     },
     "district-35": {
       "id": "district-35",
-      "name": "",
-      "desc": "",
+      "name": "Gate Garrison (West)",
+      "desc": "Inspection offices, barracks, stables, and courier post at the west gate.",
+      "tags": [
+        "security",
+        "infrastructure"
+      ],
       "points": [
         [36.25, 69.52], [37.41, 70.97], [52.86, 71.41], [52.75, 64.4], [51.69, 64.18], [46.09, 64.96], [45.56, 67.19]
       ]
     },
     "district-36": {
       "id": "district-36",
-      "name": "",
-      "desc": "",
+      "name": "Watchtower / Inner Rampart Line",
+      "desc": "Linear watchposts and signaling towers tied into patrol routes along main boulevards.",
+      "tags": [
+        "security",
+        "infrastructure"
+      ],
       "points": [
         [53.49, 64.74], [55.92, 65.18], [58.46, 65.18], [58.36, 66.18], [53.91, 70.63]
       ]
     },
     "district-37": {
       "id": "district-37",
-      "name": "",
-      "desc": "",
+      "name": "Museum / Memorial Corridor",
+      "desc": "Shinobi-history exhibits and small theatre connecting to village memorials.",
+      "tags": [
+        "civic",
+        "historic",
+        "arts"
+      ],
       "points": [
         [65.55, 63.96], [68.51, 68.41], [69.36, 66.63], [72.53, 65.07], [70.2, 63.4], [74.86, 56.84], [76.76, 56.62], [76.44, 53.62], [69.67, 58.4]
       ]
     },
     "district-38": {
       "id": "district-38",
-      "name": "",
-      "desc": "",
+      "name": "Hokage Monument Hillside / Quarry Works",
+      "desc": "Maintenance yards, lift access, and sculpting platforms for the Monument; stone quarry remnants.",
+      "tags": [
+        "infrastructure",
+        "historic"
+      ],
       "points": [
         [77.39, 53.39], [77.71, 56.62], [80.36, 57.17], [81.1, 59.29], [87.13, 53.17], [83.21, 53.39], [83.21, 54.73], [81.41, 54.95], [80.89, 53.5]
       ]
     },
     "district-39": {
       "id": "district-39",
-      "name": "",
-      "desc": "",
+      "name": "Zoo & Aviary",
+      "desc": "Small shinobi-creature enclosures and messenger-bird aviary linked to nearby parks.",
+      "tags": [
+        "park",
+        "civic",
+        "education"
+      ],
       "points": [
         [81.52, 61.96], [84.27, 61.29], [82.79, 59.29], [87.34, 54.51], [86.39, 61.62], [85.12, 64.52], [79.72, 68.63], [81.94, 65.29]
       ]


### PR DESCRIPTION
## Summary
- fill in names, descriptions and category tags for districts 2-39 in map default data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cf7007ec8332b709628289eca1e6