### PR TITLE
Validate city slice buildings within districts

### DIFF
--- a/src/game/objects/placements/citySlice.js
+++ b/src/game/objects/placements/citySlice.js
@@ -1,9 +1,45 @@
 import * as THREE from 'three';
 // NOTE: this file is at /src/game/objects/placements/, so we must go up THREE levels to reach /src/components/...
 import { addKonohaCitySlice } from '../../../components/game/objects/citySlice.js';
+import { WORLD_SIZE } from '/src/scene/terrain.js';
+import { DEFAULT_DISTRICTS } from '../../../../map/defaults/parts/districts.js';
 
 // Global scale factor for the city slice buildings
 const CITY_SLICE_SCALE = 0.5;
+
+// Precompute district polygons in world coordinates for quick point-in-poly tests.
+const DISTRICT_POLYGONS = Object.values(DEFAULT_DISTRICTS).map(d =>
+  d.points.map(([px, py]) => ({
+    x: (px / 100) * WORLD_SIZE - WORLD_SIZE / 2,
+    z: (py / 100) * WORLD_SIZE - WORLD_SIZE / 2
+  }))
+);
+
+function pointInPolygon(point, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x, zi = polygon[i].z;
+    const xj = polygon[j].x, zj = polygon[j].z;
+    const intersect = ((zi > point.z) !== (zj > point.z)) &&
+      (point.x < ((xj - xi) * (point.z - zi)) / (zj - zi + 1e-7) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function isBuildingInsideDistricts(building) {
+  building.updateWorldMatrix(true, false);
+  const box = new THREE.Box3().setFromObject(building);
+  const corners = [
+    { x: box.min.x, z: box.min.z },
+    { x: box.max.x, z: box.min.z },
+    { x: box.max.x, z: box.max.z },
+    { x: box.min.x, z: box.max.z }
+  ];
+  return DISTRICT_POLYGONS.some(poly =>
+    corners.every(corner => pointInPolygon(corner, poly))
+  );
+}
 
 // Build the Konoha city slice and add it to the scene with collision proxies.
 // Returns the slice group or null on failure.
@@ -50,8 +86,15 @@ export function placeCitySlice(scene, objectGrid, settings, origin = new THREE.V
       scene.add(proxy);
     };
 
-    // Register proxies for all buildings in the slice
-    slice.children.forEach((building) => addObbProxy(building));
+    // Register proxies for all buildings that lie inside a district
+    slice.children.slice().forEach((building) => {
+      if (isBuildingInsideDistricts(building)) {
+        addObbProxy(building);
+      } else {
+        console.warn('Removing building outside district bounds:', building.name || building.id);
+        slice.remove(building);
+      }
+    });
 
     return slice;
   } catch (e) {


### PR DESCRIPTION
## Summary
- ensure citySlice building placement respects district polygons
- skip and log buildings that fall outside any district boundaries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a9acb688332bb9aa664b3541358